### PR TITLE
Add support for highlighting role mentions

### DIFF
--- a/app/presenters/custom_formatters/slodown_with_extensions.rb
+++ b/app/presenters/custom_formatters/slodown_with_extensions.rb
@@ -2,5 +2,6 @@ module CustomFormatters
   class SlodownWithExtensions < Slodown::Formatter
     include WithMentions
     include WithReferences
+    include WithRoleMentions
   end
 end

--- a/app/presenters/custom_formatters/with_role_mentions.rb
+++ b/app/presenters/custom_formatters/with_role_mentions.rb
@@ -1,0 +1,21 @@
+module CustomFormatters
+  module WithRoleMentions
+    def highlight_role_mentions
+      @current = mentioned_roles.inject(@current) do |text, role|
+        text.gsub(/@#{role}\b/i, mention_span(role))
+      end
+      self
+    end
+
+    private
+    def mentioned_roles
+      Actions::ExtractRoleMentions.new(@current)
+        .perform
+        .mentioned_roles
+    end
+
+    def mention_span(role)
+      "<span class=\"hl-macro hl-macro-#{role.pluralize}\">@#{role.pluralize}</span>"
+    end
+  end
+end

--- a/app/presenters/user_markup_renderer.rb
+++ b/app/presenters/user_markup_renderer.rb
@@ -9,6 +9,7 @@ module UserMarkupRenderer
       CustomFormatters::SlodownWithExtensions.new(value)
         .link_mentions
         .handle_references
+        .highlight_role_mentions
         .markdown
         .autolink
         .sanitize


### PR DESCRIPTION
User markup rendering pipeline now wraps @admin/@editor with
span tags as requested in griffithlab/civic-client#785