### PR TITLE
Make comment counts consistent.

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -36,4 +36,12 @@ class Comment < ActiveRecord::Base
       end
     end
   end
+
+  def self.timepoint_query
+    ->(x) {
+      Event.where(action: 'commented')
+        .where('events.created_at >= ?', x)
+        .distinct
+    }
+  end
 end

--- a/app/models/leaderboard.rb
+++ b/app/models/leaderboard.rb
@@ -19,7 +19,7 @@ class Leaderboard
   end
 
   def most_comments
-    data_for_action('commented')
+    data_for_action('commented', true)
   end
 
   def most_suggested_changes
@@ -35,8 +35,8 @@ class Leaderboard
     ])
   end
 
-  def data_for_action(action)
-    users_for_action(action).map.with_index(1) do |user, index|
+  def data_for_action(action, include_unlinkable = false)
+    users_for_action(action, include_unlinkable).map.with_index(1) do |user, index|
       {
         rank: index,
         count: user.event_count,
@@ -45,12 +45,17 @@ class Leaderboard
     end
   end
 
-  def users_for_action(action)
-    User.joins(:events)
-      .where('events.action' => action, 'events.unlinkable' => false)
+  def users_for_action(action, include_unlinkable = false)
+    query = User.joins(:events)
+      .where('events.action' => action)
       .group('users.id')
       .select('users.*, COUNT(DISTINCT(events.id)) as event_count')
       .order('event_count DESC')
       .limit(10)
+    if include_unlinkable
+      query
+    else
+      query.where('events.unlinkable' => false)
+    end
   end
 end


### PR DESCRIPTION
Comment counts are now always generated via Event counting. This
includes the leaderboard, site stats, and user profile pages. Counts now
consistently exclude auto-generated comments that are created as the
result of evidence item/change submissions and only include comments the
user actually made.

Closes griffithlab/civic-client#792