### PR TITLE
Fix boolean regex check

### DIFF
--- a/app/controllers/concerns/with_badges.rb
+++ b/app/controllers/concerns/with_badges.rb
@@ -10,7 +10,7 @@ module WithBadges
   end
 
   def award_badges
-    if signed_in? && ! controller_path =~ /admin/
+    if signed_in? && controller_path !~ /admin/
       begin
         AwardBadges.perform_later(current_user, controller_name, action_name, params.except('format'))
       rescue ActiveJob::SerializationError


### PR DESCRIPTION
The existing conditional was always returning a falsey value meaning
that the badge awarding rules were not always being run when they should
be. This fixes that.

Closes griffithlab/civic-client#793

NOTE: Once this is deployed, we'll want to do a one-off re-run of all the rules against everyone's account to make sure they have the badges they rightfully deserve!