### PR TITLE
Add info to the "qualifying variants" CIViC Panel response

### DIFF
--- a/app/controllers/panels_controller.rb
+++ b/app/controllers/panels_controller.rb
@@ -21,7 +21,7 @@ class PanelsController < ApplicationController
       _meta: {
         total_count: variants.size
       },
-      records: variants.map { |v| VariantIndexPresenter.new(v) }
+      records: variants.map { |v| QualifyingVariantPresenter.new(v) }
     }
   end
 end

--- a/app/models/civic_panel.rb
+++ b/app/models/civic_panel.rb
@@ -7,7 +7,7 @@ class CivicPanel
   end
 
   def variants
-    variants = PipelineType.includes(variant_types: {variants: [:evidence_items, :gene]})
+    variants = PipelineType.includes(variant_types: {variants: [gene: [], variant_types: [], evidence_items: [:disease, :source, :drugs, :open_changes]]})
                  .find_by('lower(pipeline_types.name) = ?', pipeline_type)
                  .variant_types
                  .flat_map(&:variants)

--- a/app/presenters/qualifying_variant_presenter.rb
+++ b/app/presenters/qualifying_variant_presenter.rb
@@ -1,0 +1,10 @@
+class QualifyingVariantPresenter < VariantIndexPresenter
+  def as_json(opt = {})
+    super.merge(
+      {
+        variant_url: LinkAdaptors::Variant.new(variant).path,
+        evidence_items: variant.evidence_items.map { |ei| EvidenceItemIndexPresenter.new(ei) }
+      }
+    )
+  end
+end


### PR DESCRIPTION
Variants now include the url to the variant on the website as well as
the corresponding evidence items.