### PR TITLE
Tidy up lifecycle events

### DIFF
--- a/app/models/concerns/commentable.rb
+++ b/app/models/concerns/commentable.rb
@@ -1,0 +1,12 @@
+module Commentable
+  extend ActiveSupport::Concern
+  included do
+    acts_as_commentable
+
+    has_one :last_comment_event,
+      ->() { where(action: 'commented').includes(:originating_user).order('created_at DESC') },
+      as: :subject,
+      class_name: Event
+  end
+
+end

--- a/app/models/evidence_item.rb
+++ b/app/models/evidence_item.rb
@@ -7,7 +7,7 @@ class EvidenceItem < ActiveRecord::Base
   include SoftDeletable
   include WithCountableEnum
   include Flaggable
-  acts_as_commentable
+  include Commentable
 
   belongs_to :source
   belongs_to :disease
@@ -29,6 +29,10 @@ class EvidenceItem < ActiveRecord::Base
     as: :subject,
     class_name: Event
   has_one :rejector, through: :rejection_event, source: :originating_user
+  has_one :current_status_event,
+    ->(ei) { where(action: ei.status).includes(:originating_user).order('created_at DESC') },
+    as: :subject,
+    class_name: Event
 
   alias_attribute :text, :description
 
@@ -156,11 +160,12 @@ class EvidenceItem < ActiveRecord::Base
   def lifecycle_events
     {
       submitted: :submission_event,
-      accepted: :acceptance_event,
-      rejected: :rejection_event,
       last_modified: :last_applied_change,
-      last_reviewed: :last_review_event
-    }
+      last_reviewed: :last_review_event,
+      last_commented_on: :last_comment_event
+    }.tap do |events_hash|
+      events_hash[self.status.to_sym] = :current_status_event
+    end
   end
 
   def after_change_accept(change)

--- a/app/models/flag.rb
+++ b/app/models/flag.rb
@@ -1,6 +1,6 @@
 class Flag < ActiveRecord::Base
-  acts_as_commentable
   include Subscribable
+  include Commentable
   belongs_to :flaggable, polymorphic: true
   belongs_to :flagging_user, class_name: User
   belongs_to :resolving_user, class_name: User

--- a/app/models/gene.rb
+++ b/app/models/gene.rb
@@ -6,7 +6,7 @@ class Gene < ActiveRecord::Base
   include SoftDeletable
   include WithDomainExpertTags
   include Flaggable
-  acts_as_commentable
+  include Commentable
 
   has_many :variants
   has_many :secondary_variants, class_name: 'Variant', foreign_key: 'secondary_gene_id'
@@ -70,7 +70,8 @@ class Gene < ActiveRecord::Base
   def lifecycle_events
     {
       last_modified: :last_applied_change,
-      last_reviewed: :last_review_event
+      last_reviewed: :last_review_event,
+      last_commented_on: :last_comment_event
     }
   end
 end

--- a/app/models/source.rb
+++ b/app/models/source.rb
@@ -1,7 +1,7 @@
 class Source < ActiveRecord::Base
   include WithTimepointCounts
   include Subscribable
-  acts_as_commentable
+  include Commentable
 
   has_many :evidence_items
   has_and_belongs_to_many :genes

--- a/app/models/suggested_change.rb
+++ b/app/models/suggested_change.rb
@@ -2,7 +2,7 @@ class SuggestedChange < ActiveRecord::Base
   include Subscribable
   include WithAudits
   include WithTimepointCounts
-  acts_as_commentable
+  include Commentable
 
   belongs_to :user
   belongs_to :moderated, polymorphic: true

--- a/app/models/variant.rb
+++ b/app/models/variant.rb
@@ -6,7 +6,7 @@ class Variant < ActiveRecord::Base
   include SoftDeletable
   include WithDomainExpertTags
   include Flaggable
-  acts_as_commentable
+  include Commentable
 
   belongs_to :gene
   belongs_to :secondary_gene, class_name: 'Gene'
@@ -94,7 +94,8 @@ class Variant < ActiveRecord::Base
   def lifecycle_events
     {
       last_modified: :last_applied_change,
-      last_reviewed: :last_review_event
+      last_reviewed: :last_review_event,
+      last_commented_on: :last_review_event,
     }
   end
 

--- a/app/models/variant_group.rb
+++ b/app/models/variant_group.rb
@@ -4,7 +4,7 @@ class VariantGroup < ActiveRecord::Base
   include WithAudits
   include SoftDeletable
   include Flaggable
-  acts_as_commentable
+  include Commentable
 
   has_many :variant_group_variants
   has_many :variants, through: :variant_group_variants
@@ -56,7 +56,8 @@ class VariantGroup < ActiveRecord::Base
   def lifecycle_events
     {
       last_modified: :last_applied_change,
-      created: :creation_audit
+      created: :creation_audit,
+      last_commented_on: :last_review_event,
     }
   end
 end

--- a/app/presenters/lifecycle_presenter.rb
+++ b/app/presenters/lifecycle_presenter.rb
@@ -6,7 +6,6 @@ class LifecyclePresenter
   end
 
   def as_json(opts = {})
-    index = 0
     subject.lifecycle_events.each_with_object({}) do |(event_name, relation_name), h|
       if event = subject.send(relation_name)
         user = if event.respond_to?(:originating_user)
@@ -15,11 +14,9 @@ class LifecyclePresenter
                  event.user
                end
         h[event_name] = {
-          order: index,
           timestamp: event.created_at,
           user: UserPresenter.new(user)
         }
-        index += 1
       end
     end
   end


### PR DESCRIPTION
As discussed in #339, evidence items will only
display user attribution for their current status rather than all
previous ones. Additionally, introduce a "last commented" attribution.

@jmcmichael will still need to sort the event entries by timestamp as noted in https://github.com/griffithlab/civic-server/issues/340

Closes #339