### PR TITLE
Add endpoint for all evidence items in a variant group

### DIFF
--- a/app/controllers/evidence_items_controller.rb
+++ b/app/controllers/evidence_items_controller.rb
@@ -2,7 +2,7 @@ class EvidenceItemsController < ApplicationController
   include WithComment
   include WithSoftDeletion
 
-  actions_without_auth :index, :show, :variant_index
+  actions_without_auth :index, :show, :variant_index, :variant_group_index
 
   def index
     items = EvidenceItem.index_scope
@@ -34,6 +34,21 @@ class EvidenceItemsController < ApplicationController
     )
   end
 
+  def variant_group_index
+    variants = EvidenceItem.variant_group_scope
+      .order('evidence_items.id asc')
+      .page(params[:page].to_i)
+      .per(params[:count].to_i)
+      .where(variant_groups: { id: params[:variant_id] })
+      .uniq
+
+    render json: PaginatedCollectionPresenter.new(
+      variants,
+      request,
+      EvidenceItemIndexPresenter,
+      PaginationPresenter
+    )
+  end
   def propose
     authorize EvidenceItem.new
     result = EvidenceItem.propose(

--- a/app/controllers/evidence_items_controller.rb
+++ b/app/controllers/evidence_items_controller.rb
@@ -39,7 +39,7 @@ class EvidenceItemsController < ApplicationController
       .order('evidence_items.id asc')
       .page(params[:page].to_i)
       .per(params[:count].to_i)
-      .where(variant_groups: { id: params[:variant_id] })
+      .where(variant_groups: { id: params[:variant_group_id] })
       .uniq
 
     render json: PaginatedCollectionPresenter.new(

--- a/app/models/evidence_item.rb
+++ b/app/models/evidence_item.rb
@@ -75,7 +75,7 @@ class EvidenceItem < ActiveRecord::Base
   end
 
   def self.variant_group_scope
-    eager_load(variant: [:variant_groups])
+    eager_load(:disease, :source, :drugs, :open_changes, variant: [:variant_groups])
   end
 
   def name

--- a/app/models/evidence_item.rb
+++ b/app/models/evidence_item.rb
@@ -74,6 +74,10 @@ class EvidenceItem < ActiveRecord::Base
     eager_load(:submitter, :disease, :source, :drugs, :open_changes, variant: [:gene, :variant_aliases])
   end
 
+  def self.variant_group_scope
+    eager_load(variant: [:variant_groups])
+  end
+
   def name
     "EID#{id}"
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -69,6 +69,7 @@ Rails.application.routes.draw do
 
     resources 'variant_groups', except: [:edit] do
       get 'variants' => 'variants#variant_group_index'
+      get 'evidence_items' => 'evidence_items#variant_group_index'
       concerns :audited, controller: 'variant_group_audits'
       concerns :moderated, controller: 'variant_group_moderations'
       concerns :flaggable, controller: 'variant_group_flags'


### PR DESCRIPTION
This implements the endpoint necessary for https://github.com/griffithlab/civic-client/issues/800.

The endpoint can be found at `api/variant_groups/:id/evidence_items`.