### PR TITLE
Add endpoint for all evidence items of an organization

### DIFF
--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -45,7 +45,7 @@ class OrganizationsController < ApplicationController
   def evidence_items
     evidence_items = EvidenceItem.order('evidence_items.id DESC')
       .eager_load(:submitter)
-      .where('users.id': user_ids)
+      .where('users.id' => user_ids)
       .page(params[:page])
       .per(params[:count])
 

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -44,6 +44,7 @@ class OrganizationsController < ApplicationController
 
   def evidence_items
     evidence_items = EvidenceItem.order('evidence_items.id DESC')
+      .index_scope
       .eager_load(:submitter)
       .where('users.id' => user_ids)
       .page(params[:page])

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -170,6 +170,7 @@ Rails.application.routes.draw do
     get '/badges' => 'badge_claim#index'
 
     resources 'organizations', only: [:index, :show] do
+      get 'evidence_items' => 'organizations#evidence_items'
       get 'events' => 'organizations#events'
       get 'stats' => 'organizations#stats'
     end


### PR DESCRIPTION
These are evidence items that were submitted by a user of that organization.

The new endpoint can be found at `api/organizations/:id/evidence_items`.