### PR TITLE
A few bugfixes in the variants controller

### DIFF
--- a/app/controllers/variants_controller.rb
+++ b/app/controllers/variants_controller.rb
@@ -59,7 +59,7 @@ class VariantsController < ApplicationController
   def destroy
     variant = Variant.view_scope.find_by!(id: params[:id])
     authorize variant
-    soft_delete(variat, VariantDetailPresenter)
+    soft_delete(variant, VariantDetailPresenter)
   end
 
   def datatable

--- a/app/controllers/variants_controller.rb
+++ b/app/controllers/variants_controller.rb
@@ -40,7 +40,7 @@ class VariantsController < ApplicationController
       .page(params[:page].to_i)
       .per(params[:count].to_i)
       .joins(:variant_groups)
-      .where(variant_groups: { id: params[:variant_id] })
+      .where(variant_groups: { id: params[:variant_group_id] })
       .uniq
 
     render json: PaginatedCollectionPresenter.new(


### PR DESCRIPTION
There was a bug in the `variant_group_index` where it would search by `variant_id` instead of `variant_group_id`.

This also fixes a typo for the `variant` variable in the `destroy` method.