### PR TITLE
New endpoint for typeahead drug search of existing drugs

### DIFF
--- a/app/controllers/drugs_controller.rb
+++ b/app/controllers/drugs_controller.rb
@@ -1,6 +1,6 @@
 class DrugsController < ApplicationController
 
-  actions_without_auth :index, :existence, :name_suggestion
+  actions_without_auth :index, :existence, :name_suggestion, :local_name_suggestion
 
   def index
     drugs = Drug.page(params[:page])
@@ -30,6 +30,14 @@ class DrugsController < ApplicationController
       render json:  {errors: ['Must specify a query with parameter q']}, status: :bad_request
     else
       render json: DrugNameSuggestion.suggestions_for_name(params[:q]), status: :ok
+    end
+  end
+
+  def local_name_suggestion
+    if params[:q].blank?
+      render json:  {errors: ['Must specify a query with parameter q']}, status: :bad_request
+    else
+      render json: DrugNameSuggestion.get_local_suggestions(params[:q]), status: :ok
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -162,6 +162,7 @@ Rails.application.routes.draw do
     get '/drugs' => 'drugs#index'
     get '/drugs/existence/:pubchem_id' => 'drugs#existence'
     get '/drugs/suggestions' => 'drugs#name_suggestion'
+    get '/drugs/local_suggestions' => 'drugs#local_name_suggestion'
     get '/acmg_codes' => 'acmg_codes#index'
     get '/regulatory_agencies' => 'regulatory_agencies#index'
 


### PR DESCRIPTION
This is needed for the assertions form because we only want to allow the users to pick drugs that are already in our database and therefore used for evidence items.

The new endpoint is at `api/drugs/local_suggestions?q=`