### PR TITLE
Allow source search by variant and gene name

### DIFF
--- a/app/models/advanced_searches/source.rb
+++ b/app/models/advanced_searches/source.rb
@@ -24,6 +24,8 @@ module AdvancedSearches
         'author' => default_handler.curry[['authors.fore_name', 'authors.last_name']],
         'evidence_item_count' => method(:handle_evidence_item_count),
         'source_suggestion_count' => method(:handle_source_suggestion_count),
+        'gene' => default_handler.curry['genes.name'],
+        'variant' => default_handler.curry['variants.name'],
       }
       @handlers[field]
     end

--- a/app/models/source.rb
+++ b/app/models/source.rb
@@ -22,7 +22,7 @@ class Source < ActiveRecord::Base
   end
 
   def self.advanced_search_scope
-    eager_load(:evidence_items, authors_sources: [:author])
+    eager_load(evidence_items: [variant: [:gene]], authors_sources: [:author])
   end
 
   def self.datatable_scope


### PR DESCRIPTION
I believe that these are all the changes needed on the server side to support advanced source searches by variant or gene names. I haven't tested this yet.

Closes https://github.com/griffithlab/civic-server/issues/372.