### PR TITLE
added /public/system to gitignore, keeping admin-uploaded assets out of repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,5 +19,8 @@ tmp/tmp
 tmp/
 *.DS_Store
 
+# ignore system resources
+/public/system
+
 # Ignore data dumps in dev environment
 db/localdb.sql


### PR DESCRIPTION
While working on the organizations page, needed to upload organization avatar images. This created a /public/system folder that shouldn't be included in the repo in order to avoid conflicts w/ the production assets directory.