### PR TITLE
Share sorting clause code between controllers.

### DIFF
--- a/app/controllers/concerns/with_sorting.rb
+++ b/app/controllers/concerns/with_sorting.rb
@@ -1,0 +1,13 @@
+module WithSorting
+  extend ActiveSupport::Concern
+
+  def sort_direction(field_name)
+    if params["sorting"].blank?
+      'DESC'
+    elsif params["sorting"][field_name].present? && params["sorting"][field_name].upcase == 'DESC'
+      'DESC'
+    else
+      'ASC'
+    end
+  end
+end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,24 +1,14 @@
 class EventsController < ApplicationController
+  include WithSorting
+
   actions_without_auth :index
 
   def index
     events = Event.includes(:originating_user, :subject)
       .page(params[:page])
       .per(params[:count])
-      .order("events.created_at #{sort_clause}")
+      .order("events.created_at #{sort_direction('timestamp')}")
 
     render json: EventsPresenter.new(events)
-  end
-
-
-  private
-  def sort_clause
-    if params["sorting"].blank?
-      'DESC'
-    elsif params["sorting"]["timestamp"].present? && params["sorting"]["timestamp"].upcase == 'DESC'
-      'DESC'
-    else
-      'ASC'
-    end
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,6 @@
 class UsersController < ApplicationController
   include WithSoftDeletion
+  include WithSorting
 
   actions_without_auth :events, :show, :index, :username_suggestions, :username_status
 
@@ -17,7 +18,7 @@ class UsersController < ApplicationController
       .includes(:subject)
       .page(params[:page])
       .per(params[:count])
-      .order('created_at DESC')
+      .order("events.created_at #{sort_direction('timestamp')}")
 
     render json: EventsPresenter.new(events)
   end


### PR DESCRIPTION
Fixes sorting events on user activity page.

I can't reproduce #383, and am currently thinking its a caching issue, but in investigating it, this bug was discovered. So... yay?