### PR TITLE
New typeahead search for gene names

### DIFF
--- a/app/controllers/genes_controller.rb
+++ b/app/controllers/genes_controller.rb
@@ -2,8 +2,8 @@ class GenesController < ApplicationController
   include WithComment
   include WithSoftDeletion
 
-  actions_without_auth :index, :show, :mygene_info_proxy, :datatable, :entrez_show, :entrez_index, :existence
-  skip_analytics :existence, :datatable, :mygene_info_proxy
+  actions_without_auth :index, :show, :mygene_info_proxy, :datatable, :entrez_show, :entrez_index, :existence, :local_name_suggestion
+  skip_analytics :existence, :datatable, :mygene_info_proxy, :local_name_suggestion
 
   def index
     if params[:detailed] == false || params[:detailed] == 'false'
@@ -95,6 +95,14 @@ class GenesController < ApplicationController
       end
     end
     render json: to_render, status: status
+  end
+
+  def local_name_suggestion
+    if params[:q].blank?
+      render json: {errors: ['Must specify a query with parameter q']}, status: :bad_request
+    else
+      render json: GeneNameSuggestion.get_local_suggestions(params[:q]), status: :ok
+    end
   end
 
   private

--- a/app/models/gene_name_suggestion.rb
+++ b/app/models/gene_name_suggestion.rb
@@ -1,0 +1,7 @@
+class GeneNameSuggestion
+  def self.get_local_suggestions(name)
+    Gene.where('name ILIKE :name', name: "%#{name}%")
+      .limit(12)
+      .pluck(:name)
+  end
+end

--- a/app/models/gene_name_suggestion.rb
+++ b/app/models/gene_name_suggestion.rb
@@ -1,7 +1,7 @@
 class GeneNameSuggestion
   def self.get_local_suggestions(name)
-    Gene.where('name ILIKE :name', name: "%#{name}%")
+    genes = Gene.where('name ILIKE :name', name: "%#{name}%")
       .limit(12)
-      .pluck(:name)
+    genes.map { |g| { id: g.id, name: g.name, entrez_id: g.entrez_id, aliases: g.gene_aliases.map(&:name)} }
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -160,6 +160,7 @@ Rails.application.routes.draw do
     get '/diseases' => 'diseases#index'
     get '/diseases/existence/:doid' => 'diseases#existence'
     get '/genes/existence/:entrez_id' => 'genes#existence'
+    get '/genes/local_suggestions/:q' => 'genes#local_name_suggestion'
     get '/drugs' => 'drugs#index'
     get '/drugs/existence/:pubchem_id' => 'drugs#existence'
     get '/drugs/suggestions' => 'drugs#name_suggestion'


### PR DESCRIPTION
The endpoint for this is `api/genes/local_suggestions/<search_term>`. This is slightly different from the local suggestions endpoint for drugs which is necessary because genes are a first order entity and the drug endpoint format doesn't work for it.