### PR TITLE
Add handling of flags during variant merging

### DIFF
--- a/app/jobs/merge_variants.rb
+++ b/app/jobs/merge_variants.rb
@@ -8,6 +8,7 @@ class MergeVariants < ActiveJob::Base
     ActiveRecord::Base.transaction do
       transfer_evidence_items
       remove_suggested_changes
+      transfer_flags
       transfer_subcriptions
       remove_variant
     end
@@ -25,6 +26,16 @@ class MergeVariants < ActiveJob::Base
     removed_variant.suggested_changes.each do |sc|
       sc.delete
       sc.save
+    end
+  end
+
+  def transfer_flags
+    removed_variant.flags.each do |f|
+      comment = f.comments.first
+      comment.comment = "(Merged from #{removed_variant.display_name}) #{f.comments.first.comment}"
+      comment.save
+      f.flaggable = remaining_variant
+      f.save
     end
   end
 


### PR DESCRIPTION
Addresses #390 

This PR will change the behavior of merging variants to move flags of the variant to be deleted to the other variant and prepend ‘(Merged from [variant name])’ to the flag comment.

We still need to fix the production instance by moving the flag manually or resolving it.