### PR TITLE
Allow links to work with AID and EID for assertions and evidence items

### DIFF
--- a/app/models/assertion.rb
+++ b/app/models/assertion.rb
@@ -65,7 +65,11 @@ class Assertion < ActiveRecord::Base
   end
 
   def name
-    "AID#{self.id}"
+    "#{tag}#{id}"
+  end
+
+  def tag
+    "AID"
   end
 
   def pending_evidence

--- a/app/models/evidence_item.rb
+++ b/app/models/evidence_item.rb
@@ -79,7 +79,11 @@ class EvidenceItem < ActiveRecord::Base
   end
 
   def name
-    "EID#{id}"
+    "#{tag}#{id}"
+  end
+
+  def tag
+    "EID"
   end
 
   def parent_subscribables

--- a/app/models/frontend_router.rb
+++ b/app/models/frontend_router.rb
@@ -10,6 +10,9 @@ class FrontendRouter
     if [entity, query_field, id].any? { |i| i.blank? }
       nil
     else
+      if entity.new.respond_to?('tag')
+        id.sub!(entity.new.tag, '')
+      end
       obj = entity.find_by!(query_field => id)
       adaptor = "LinkAdaptors::#{obj.class}".constantize.new(obj)
       "#{domain}#{adaptor.base_path}"


### PR DESCRIPTION
This will allow `links/assertions/AID<id>` and `links/evidence_items/EID<id>` to work.