### PR TITLE
Passenger restart on deploy

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,7 +79,7 @@ GEM
       sass (~> 3.2)
       thor
     builder (3.2.2)
-    capistrano (3.9.0)
+    capistrano (3.9.1)
       airbrussh (>= 1.0.0)
       i18n
       rake (>= 10.0.0)
@@ -116,6 +116,7 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.10.0)
+    concurrent-ruby (1.0.5)
     coveralls (0.8.15)
       json (>= 1.8, < 3)
       simplecov (~> 0.12.0)
@@ -150,7 +151,8 @@ GEM
       activesupport (>= 3.2, < 5)
     hashie (3.4.6)
     hike (1.2.3)
-    i18n (0.7.0)
+    i18n (0.9.5)
+      concurrent-ruby (~> 1.0)
     inherited_resources (1.6.0)
       actionpack (>= 3.2, < 5)
       has_scope (~> 0.6.0.rc)
@@ -190,7 +192,7 @@ GEM
     multipart-post (2.0.0)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
-    net-ssh (4.1.0)
+    net-ssh (4.2.0)
     nokogiri (1.6.8)
       mini_portile2 (~> 2.1.0)
       pkg-config (~> 1.1.7)
@@ -278,7 +280,7 @@ GEM
       activesupport (= 4.2.7.1)
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
-    rake (11.2.2)
+    rake (12.3.1)
     ransack (1.8.2)
       actionpack (>= 3.0)
       activerecord (>= 3.0)
@@ -341,7 +343,7 @@ GEM
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       sprockets (>= 2.8, < 4.0)
-    sshkit (1.14.0)
+    sshkit (1.16.1)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
     staccato (0.4.7)
@@ -417,4 +419,4 @@ DEPENDENCIES
   yajl-ruby (~> 1.2.1)
 
 BUNDLED WITH
-   1.15.3
+   1.15.4

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -1,4 +1,4 @@
-server "ec2-34-217-230-24.us-west-2.compute.amazonaws.com", user: 'ubuntu', roles: %w{web}
+server "ec2-34-217-230-24.us-west-2.compute.amazonaws.com", user: 'ubuntu', roles: %w{web app}
 
 set :rbenv_ruby, '2.3.4'
 

--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -1,4 +1,4 @@
-server "ec2-34-211-20-19.us-west-2.compute.amazonaws.com", user: 'ubuntu', roles: %w{web db}
+server "ec2-34-211-20-19.us-west-2.compute.amazonaws.com", user: 'ubuntu', roles: %w{web db app}
 
 set :rbenv_ruby, '2.3.4'
 

--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -4,6 +4,8 @@ set :rbenv_ruby, '2.3.4'
 
 set :branch, 'staging'
 
+set :linked_files, fetch(:linked_files, []).push('public/assets/images/favicon.png')
+
 set :ssh_options, {
   keys: ENV['CIVIC_STAGING_KEY'],
   forward_agent: false,


### PR DESCRIPTION
This commit updates `capistrano-passenger` and adds the `app` role to deploy scripts to facilitate passenger restart on deploy.

With this change, we should not need to restart Apache to get the app to update.