### PR TITLE
Uniq the list of clinical trial ids before creating new entries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ script:
   - bundle exec rake db:schema:load
   - bundle exec rake spec
 rvm:
-  - "2.1.0"
+  - "2.1.9"
 env:
   - RAILS_ENV=test TRAVIS_BUILD=true
 notifications:

--- a/lib/scrapers/pub_med.rb
+++ b/lib/scrapers/pub_med.rb
@@ -43,7 +43,7 @@ module Scrapers
       source.full_journal_title = resp.full_journal_title
       source.abstract = resp.abstract
       source.is_review = resp.is_review?
-      clinical_trials = resp.clinical_trial_ids.map do |nct_id|
+      clinical_trials = resp.clinical_trial_ids.uniq.map do |nct_id|
         ClinicalTrial.where(nct_id: nct_id).first_or_create
       end
       source.clinical_trials = clinical_trials


### PR DESCRIPTION
Otherwise, for pubmed entries where the clinical trials id gets returned in duplicate, the source gets linked to the clinical trial entry twice.

Closes https://github.com/griffithlab/civic-client/issues/912