### PR TITLE
Fix sort order on browse tables

### DIFF
--- a/app/datatables/assertion_browse_table.rb
+++ b/app/datatables/assertion_browse_table.rb
@@ -25,6 +25,7 @@ class AssertionBrowseTable < DatatableBase
     'phenotypes' => 'phenotypes.hpo_class',
     'status' => 'assertions.status',
     'variant_origin' => 'assertions.variant_origin',
+    'evidence_item_count' => 'evidence_item_count',
   }
 
   def filter(objects)

--- a/app/datatables/datatable_base.rb
+++ b/app/datatables/datatable_base.rb
@@ -65,7 +65,8 @@ class DatatableBase
 
   def order(objects)
     if sort_params = params['sorting']
-      sort_params.inject(objects) do |o, (col, direction)|
+      params['sort_priority'].split(',').inject(objects) do |o, (col)|
+        direction = params['sorting'][col]
         if actual_col = order_column(col)
           o.order("#{actual_col} #{sort_direction(direction)} NULLS LAST")
         else

--- a/app/datatables/evidence_item_browse_table.rb
+++ b/app/datatables/evidence_item_browse_table.rb
@@ -21,7 +21,7 @@ class EvidenceItemBrowseTable < DatatableBase
   ORDER_COLUMN_MAP = {
     'id' => 'evidence_items.id',
     'description' => 'evidence_items.description',
-    'variant_name' => 'variants_name',
+    'variant_name' => 'variants.name',
     'gene_name' => 'genes.name',
     'disease' => 'diseases.name',
     'drugs' => 'drug_names',


### PR DESCRIPTION
This PR adds handling of the new `sort_priority` parameter that gets sent along for browse tables. This parameter denotes in which order the sorting parameters should be applied.

This PR also fixes a couple of bugs/issues related to with ordering columns.

Requires https://github.com/griffithlab/civic-client/pull/926.