### PR TITLE
Initialize the civic_actionability_score to 0 when a variant is first created

### DIFF
--- a/app/models/actions/propose_evidence_item.rb
+++ b/app/models/actions/propose_evidence_item.rb
@@ -38,7 +38,7 @@ module Actions
         .where('lower(variants.name) = ?', params[:variant][:name].downcase).first
         variant
       else
-        Variant.create(gene: Gene.find_by(id: params[:gene][:id]), name: params[:variant][:name], description: '')
+        Variant.create(gene: Gene.find_by(id: params[:gene][:id]), name: params[:variant][:name], description: '', civic_actionability_score: 0)
       end
     end
 

--- a/app/models/actions/propose_evidence_item.rb
+++ b/app/models/actions/propose_evidence_item.rb
@@ -38,7 +38,7 @@ module Actions
         .where('lower(variants.name) = ?', params[:variant][:name].downcase).first
         variant
       else
-        Variant.create(gene: Gene.find_by(id: params[:gene][:id]), name: params[:variant][:name], description: '', civic_actionability_score: 0)
+        Variant.create(gene: Gene.find_by(id: params[:gene][:id]), name: params[:variant][:name], description: '')
       end
     end
 

--- a/app/models/variant.rb
+++ b/app/models/variant.rb
@@ -26,7 +26,7 @@ class Variant < ActiveRecord::Base
   after_initialize :init
 
   def init
-    self.civic_actionability_score = 0
+    self.civic_actionability_score ||= 0 if self.has_attribute? :civic_actionability_score
   end
 
   def self.index_scope

--- a/app/models/variant.rb
+++ b/app/models/variant.rb
@@ -23,6 +23,12 @@ class Variant < ActiveRecord::Base
 
   enum reference_build: [:GRCh38, :GRCh37, :NCBI36]
 
+  after_initialize :init
+
+  def init
+    self.civic_actionability_score = 0
+  end
+
   def self.index_scope
     eager_load(:gene, :variant_types, :secondary_gene)
   end


### PR DESCRIPTION
Otherwise this attribute will be nil until an evidence item for the variant is accepted, which will result in the panel API endpoints failing because we are comparing the minimum score cutoff to nil values.

Closes #424 