### PR TITLE
Mentions in source suggestions trigger notifications

### DIFF
--- a/app/jobs/notify_mentioned.rb
+++ b/app/jobs/notify_mentioned.rb
@@ -1,8 +1,8 @@
 class NotifyMentioned < ActiveJob::Base
-  def perform(comment, event)
+  def perform(text, originating_user, event)
     ActiveRecord::Base.transaction do
-      mentioned_users_result = comment.extract_mentions
-      mentioned_roles_result = comment.extract_role_mentions
+      mentioned_users_result = Actions::ExtractMentions.new(text).perform
+      mentioned_roles_result = Actions::ExtractRoleMentions.new(text).perform
 
       users_to_notify = mentioned_users_result.mentioned_users.to_a +
        User.where(role: mentioned_roles_result.mentioned_role_values)
@@ -10,10 +10,10 @@ class NotifyMentioned < ActiveJob::Base
       users_to_notify.uniq.each do |user|
         Notification.create(
           type: :mention,
-          originating_user: comment.user,
+          originating_user: originating_user,
           notified_user: user,
           event: event
-        ) unless user == comment.user
+        ) unless user == originating_user
       end
     end
   end

--- a/app/models/actions/add_comment.rb
+++ b/app/models/actions/add_comment.rb
@@ -25,7 +25,7 @@ module Actions
     end
 
     def handle_mentions
-      NotifyMentioned.perform_later(comment, event)
+      NotifyMentioned.perform_later(comment.text, comment.user, event)
     end
 
     def create_event

--- a/app/models/actions/suggest_publication.rb
+++ b/app/models/actions/suggest_publication.rb
@@ -23,7 +23,9 @@ module Actions
           source.status = 'partially curated'
           source.save
         end
-        create_event
+        create_event.tap do |event|
+          NotifyMentioned.perform_later(initial_comment, originating_user, event)
+        end
       end
     end
 

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -15,16 +15,6 @@ class Comment < ActiveRecord::Base
     cmd.perform
   end
 
-  def extract_mentions
-    cmd = Actions::ExtractMentions.new(self.text)
-    cmd.perform
-  end
-
-  def extract_role_mentions
-    cmd = Actions::ExtractRoleMentions.new(self.text)
-    cmd.perform
-  end
-
   private
   def mark_events_unlinkable
     if self.commentable.respond_to?(:events)


### PR DESCRIPTION
These previously weren't working because comments on source suggestion
submissions aren't "real" comments, just a text field on the actual
`SourceSuggestion` entity. Ideally we'd refactor it so that they were
real `Comment` entities, but that's slightly more involved. For now, this
makes it so that the `NotifyMentioned` background job can accept arbitrary
text and an `Event` instead of a `Comment` and an `Event`, which works in both
cases.

Closes griffithlab/civic-client#948