### PR TITLE
Typo fix: s/exhaused/exhausted

### DIFF
--- a/app/models/actions/suggest_publication.rb
+++ b/app/models/actions/suggest_publication.rb
@@ -15,7 +15,7 @@ module Actions
     def execute
       set_source
       if source.status == 'exhausted'
-        errors << 'This source has been marked as exhaused. Please try a different publication'
+        errors << 'This source has been marked as exhausted. Please try a different publication'
         return
       end
       if create_publication_submission


### PR DESCRIPTION
(Saw this while looking at #443.)