### PR TITLE
Add an `s` so the name in the README matches the one in the civicdb.org header.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# CIViC - Clinical Interpretation of Variants in Cancer
+# CIViC - Clinical Interpretations of Variants in Cancer
 
 [![Code Climate](https://codeclimate.com/github/griffithlab/civic-server/badges/gpa.svg)](https://codeclimate.com/github/griffithlab/civic-server)
 [![Coverage Status](https://coveralls.io/repos/github/griffithlab/civic-server/badge.svg?branch=master)](https://coveralls.io/github/griffithlab/civic-server?branch=master)


### PR DESCRIPTION
It'll also match the repo description for [griffithlab/civic-client](https://github.com/griffithlab/civic-client).