### PR TITLE
Allow organizations to have parent organizations

### DIFF
--- a/app/admin/organization.rb
+++ b/app/admin/organization.rb
@@ -1,11 +1,12 @@
 ActiveAdmin.register Organization do
   menu :priority => 99
 
-  permit_params :name, :url, :description, :profile_image
+  permit_params :name, :url, :description, :profile_image, :parent_id
 
   filter :name
   filter :url
   filter :description
+  filter :parent_id
 
   form do |f|
     f.semantic_errors(*f.object.errors.keys)
@@ -14,6 +15,7 @@ ActiveAdmin.register Organization do
       f.input :url, input_html: {rows: 1}
       f.input :description
       f.input :profile_image, as: :file
+      f.input :parent_id, as: :select, collection: Organization.order(:id)
     end
     f.actions
   end
@@ -23,6 +25,7 @@ ActiveAdmin.register Organization do
     column :name
     column :url
     column :description
+    column :parent_id
     actions
   end
 
@@ -31,6 +34,7 @@ ActiveAdmin.register Organization do
       row :name
       row :url
       row :description
+      row :parent_id
     end
   end
 end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -1,5 +1,7 @@
 class Organization < ActiveRecord::Base
   has_many :users
+  belongs_to :parent, :class_name => 'Organization'
+  has_many :groups, :class_name => 'Organization', :foreign_key => 'parent_id'
 
   has_attached_file :profile_image,
     styles: { x256: '256x256', x128: '128x128', x64: '64x64', x32: '32x32', x14: '14x14' }
@@ -15,11 +17,19 @@ class Organization < ActiveRecord::Base
 
   def stats_hash
     (Hash.new { |h, k| h[k] = 0 }).tap do |accum|
-      users.each do |u|
+      all_users.each do |u|
         u.stats_hash.each do |k, v|
           accum[k] += v
         end
       end
     end
+  end
+
+  def all_users
+    users = self.users
+    self.groups.each_with_object(users) do |g, u|
+      u << g.users
+    end
+    return users
   end
 end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -3,6 +3,8 @@ class Organization < ActiveRecord::Base
   belongs_to :parent, :class_name => 'Organization'
   has_many :groups, :class_name => 'Organization', :foreign_key => 'parent_id'
 
+  validate :maximum_nesting_depth
+
   has_attached_file :profile_image,
     styles: { x256: '256x256', x128: '128x128', x64: '64x64', x32: '32x32', x14: '14x14' }
 
@@ -28,4 +30,13 @@ class Organization < ActiveRecord::Base
   def all_users
     (self.groups.includes(:users).flat_map(&:users) + self.users).uniq
   end
+
+  def maximum_nesting_depth
+    if self.parent_id.present?
+      unless self.parent.parent_id.blank?
+        errors.add(:parent, "organizations can only be nested one level deep")
+      end
+    end
+  end
+
 end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -26,10 +26,6 @@ class Organization < ActiveRecord::Base
   end
 
   def all_users
-    users = self.users
-    self.groups.each_with_object(users) do |g, u|
-      u << g.users
-    end
-    return users
+    (self.groups.includes(:users).flat_map(&:users) + self.users).uniq
   end
 end

--- a/db/migrate/20181029172630_add_parent_id_to_organization.rb
+++ b/db/migrate/20181029172630_add_parent_id_to_organization.rb
@@ -1,0 +1,6 @@
+class AddParentIdToOrganization < ActiveRecord::Migration
+  def change
+    add_column :organizations, :parent_id, :integer, null: true
+    add_foreign_key :organizations, :organizations, column: :parent_id
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1206,7 +1206,8 @@ CREATE TABLE organizations (
     profile_image_file_name character varying,
     profile_image_content_type character varying,
     profile_image_file_size integer,
-    profile_image_updated_at timestamp without time zone
+    profile_image_updated_at timestamp without time zone,
+    parent_id integer
 );
 
 
@@ -3363,6 +3364,14 @@ ALTER TABLE ONLY assertions_phenotypes
 
 
 --
+-- Name: organizations fk_rails_6551137b98; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY organizations
+    ADD CONSTRAINT fk_rails_6551137b98 FOREIGN KEY (parent_id) REFERENCES organizations(id);
+
+
+--
 -- Name: authors_sources fk_rails_6b13cd95ea; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -3823,4 +3832,6 @@ INSERT INTO schema_migrations (version) VALUES ('20180216183259');
 INSERT INTO schema_migrations (version) VALUES ('20180221154308');
 
 INSERT INTO schema_migrations (version) VALUES ('20181018132316');
+
+INSERT INTO schema_migrations (version) VALUES ('20181029172630');
 

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+describe Organization do
+  before(:each) do
+
+    @parent_org = Organization.create(name: 'parent')
+    @first_child = Organization.create(name: 'first child', parent: @parent_org)
+  end
+
+  it 'should allow organizations to have parents' do
+    expect(@parent_org.groups.to_a).to eq [@first_child]
+    expect(@first_child.parent).to eq @parent_org
+  end
+
+  it 'should only allow one level of nesting' do
+    second_child = Organization.create(name: 'foo', parent: @first_child)
+
+    expect(second_child.valid?).to be false
+    expect(second_child.errors[:parent]).to be_truthy
+  end
+
+  it 'should correctly get all members of subteams' do
+    user1 = Fabricate(:user)
+    user2 = Fabricate(:user)
+    user3 = Fabricate(:user)
+
+    user1.organization = @parent_org
+    user1.save
+
+    user2.organization = @first_child
+    user2.save
+
+    user3.organization = @first_child
+    user3.save
+
+    expect(@parent_org.all_users).to contain_exactly(user1, user2, user3)
+  end
+end


### PR DESCRIPTION
Closes https://github.com/griffithlab/civic-client/issues/965

This change allows you to add a "parent" organization for an organization. An organization then has `groups`, which are all organizations it is a direct parent of. We can then assign users to these new "group" organizations instead of their parent organization in the admin panel.

`all_users` returns a list of an organization's users and all its groups' users so with that change and the change to the `stats_hash` an organization's stats will include all the counts for its users and its groups' users.