### PR TITLE
Switch eager load to includes for event hierarchy.

### DIFF
--- a/app/models/event_hierarchy.rb
+++ b/app/models/event_hierarchy.rb
@@ -3,7 +3,7 @@ class EventHierarchy
   def initialize(subscribable)
     load_scope = self.class.hierarchy[subscribable.class][:scope]
     @subscribable = subscribable.class
-      .eager_load(load_scope)
+      .includes(load_scope)
       .find(subscribable.id)
   end
 


### PR DESCRIPTION
Instead of using one large left join, this will eager load one model at a time. Its marginally less performant in this case, but it allows eager loading of polymorphic relationships (in this case `:moderated`) which is what was breaking in griffithlab/civic-client#1015.

closes griffithlab/civic-client#1015