### PR TITLE
Return the Gene ID as gene_id rather than the Gene Entrez ID.

### DIFF
--- a/app/datatables/assertion_browse_table.rb
+++ b/app/datatables/assertion_browse_table.rb
@@ -58,9 +58,9 @@ class AssertionBrowseTable < DatatableBase
   end
 
   def select_query
-    initial_scope.select("assertions.id, assertions.status, assertions.summary, assertions.evidence_type, assertions.evidence_direction, assertions.clinical_significance, genes.name as gene_name, genes.entrez_id as gene_id, diseases.name as disease_name, array_agg(distinct(drugs.name) order by drugs.name) as drug_names, array_agg(distinct(phenotypes.hpo_class) order by phenotypes.hpo_class) as phenotype_hpo_classes, variants.name as variant_name, variants.id as variant_id, COUNT(DISTINCT(assertions_evidence_items.evidence_item_id)) as evidence_item_count")
+    initial_scope.select("assertions.id, assertions.status, assertions.summary, assertions.evidence_type, assertions.evidence_direction, assertions.clinical_significance, genes.name as gene_name, genes.id as gene_id, diseases.name as disease_name, array_agg(distinct(drugs.name) order by drugs.name) as drug_names, array_agg(distinct(phenotypes.hpo_class) order by phenotypes.hpo_class) as phenotype_hpo_classes, variants.name as variant_name, variants.id as variant_id, COUNT(DISTINCT(assertions_evidence_items.evidence_item_id)) as evidence_item_count")
       .where("assertions.status != 'rejected'")
-      .group("assertions.id, assertions.status, assertions.summary, assertions.evidence_type, assertions.evidence_direction, assertions.clinical_significance, genes.name, genes.entrez_id, diseases.name, variants.name, variants.id")
+      .group("assertions.id, assertions.status, assertions.summary, assertions.evidence_type, assertions.evidence_direction, assertions.clinical_significance, genes.name, genes.id, diseases.name, variants.name, variants.id")
   end
 
   def count_query

--- a/app/datatables/assertion_browse_table.rb
+++ b/app/datatables/assertion_browse_table.rb
@@ -58,9 +58,9 @@ class AssertionBrowseTable < DatatableBase
   end
 
   def select_query
-    initial_scope.select("assertions.id, assertions.status, assertions.summary, assertions.evidence_type, assertions.evidence_direction, assertions.clinical_significance, genes.name as gene_name, genes.id as gene_id, diseases.name as disease_name, array_agg(distinct(drugs.name) order by drugs.name) as drug_names, array_agg(distinct(phenotypes.hpo_class) order by phenotypes.hpo_class) as phenotype_hpo_classes, variants.name as variant_name, variants.id as variant_id, COUNT(DISTINCT(assertions_evidence_items.evidence_item_id)) as evidence_item_count")
+    initial_scope.select("assertions.id, assertions.status, assertions.summary, assertions.evidence_type, assertions.evidence_direction, assertions.clinical_significance, genes.name as gene_name, genes.id as gene_id, genes.entrez_id as gene_entrez_id, diseases.name as disease_name, array_agg(distinct(drugs.name) order by drugs.name) as drug_names, array_agg(distinct(phenotypes.hpo_class) order by phenotypes.hpo_class) as phenotype_hpo_classes, variants.name as variant_name, variants.id as variant_id, COUNT(DISTINCT(assertions_evidence_items.evidence_item_id)) as evidence_item_count")
       .where("assertions.status != 'rejected'")
-      .group("assertions.id, assertions.status, assertions.summary, assertions.evidence_type, assertions.evidence_direction, assertions.clinical_significance, genes.name, genes.id, diseases.name, variants.name, variants.id")
+      .group("assertions.id, assertions.status, assertions.summary, assertions.evidence_type, assertions.evidence_direction, assertions.clinical_significance, genes.name, genes.id, genes.entrez_id, diseases.name, variants.name, variants.id")
   end
 
   def count_query

--- a/app/datatables/evidence_item_browse_table.rb
+++ b/app/datatables/evidence_item_browse_table.rb
@@ -74,9 +74,9 @@ class EvidenceItemBrowseTable < DatatableBase
   end
 
   def select_query
-    initial_scope.select("evidence_items.id, evidence_items.status, evidence_items.description, evidence_items.evidence_level, evidence_items.evidence_type, evidence_items.evidence_direction, evidence_items.clinical_significance, evidence_items.variant_origin, evidence_items.rating, genes.name as gene_name, genes.id as gene_id, diseases.name as disease_name, array_agg(distinct(drugs.name) order by drugs.name) as drug_names, array_agg(distinct(phenotypes.hpo_class) order by phenotypes.hpo_class) as phenotype_hpo_classes, variants.name as variant_name, variants.id as variant_id, sources.description as source_citation, sources.name as source_title")
+    initial_scope.select("evidence_items.id, evidence_items.status, evidence_items.description, evidence_items.evidence_level, evidence_items.evidence_type, evidence_items.evidence_direction, evidence_items.clinical_significance, evidence_items.variant_origin, evidence_items.rating, genes.name as gene_name, genes.id as gene_id, genes.entrez_id as gene_entrez_id, diseases.name as disease_name, array_agg(distinct(drugs.name) order by drugs.name) as drug_names, array_agg(distinct(phenotypes.hpo_class) order by phenotypes.hpo_class) as phenotype_hpo_classes, variants.name as variant_name, variants.id as variant_id, sources.description as source_citation, sources.name as source_title")
       .where("evidence_items.status != 'rejected'")
-      .group("evidence_items.id, genes.name, genes.id, diseases.name, variants.name, variants.id, sources.description, sources.name")
+      .group("evidence_items.id, genes.name, genes.id, genes.entrez_id, diseases.name, variants.name, variants.id, sources.description, sources.name")
   end
 
   def count_query

--- a/app/datatables/evidence_item_browse_table.rb
+++ b/app/datatables/evidence_item_browse_table.rb
@@ -74,9 +74,9 @@ class EvidenceItemBrowseTable < DatatableBase
   end
 
   def select_query
-    initial_scope.select("evidence_items.id, evidence_items.status, evidence_items.description, evidence_items.evidence_level, evidence_items.evidence_type, evidence_items.evidence_direction, evidence_items.clinical_significance, evidence_items.variant_origin, evidence_items.rating, genes.name as gene_name, genes.entrez_id as gene_id, diseases.name as disease_name, array_agg(distinct(drugs.name) order by drugs.name) as drug_names, array_agg(distinct(phenotypes.hpo_class) order by phenotypes.hpo_class) as phenotype_hpo_classes, variants.name as variant_name, variants.id as variant_id, sources.description as source_citation, sources.name as source_title")
+    initial_scope.select("evidence_items.id, evidence_items.status, evidence_items.description, evidence_items.evidence_level, evidence_items.evidence_type, evidence_items.evidence_direction, evidence_items.clinical_significance, evidence_items.variant_origin, evidence_items.rating, genes.name as gene_name, genes.id as gene_id, diseases.name as disease_name, array_agg(distinct(drugs.name) order by drugs.name) as drug_names, array_agg(distinct(phenotypes.hpo_class) order by phenotypes.hpo_class) as phenotype_hpo_classes, variants.name as variant_name, variants.id as variant_id, sources.description as source_citation, sources.name as source_title")
       .where("evidence_items.status != 'rejected'")
-      .group("evidence_items.id, genes.name, genes.entrez_id, diseases.name, variants.name, variants.id, sources.description, sources.name")
+      .group("evidence_items.id, genes.name, genes.id, diseases.name, variants.name, variants.id, sources.description, sources.name")
   end
 
   def count_query

--- a/app/presenters/assertion_browse_row_presenter.rb
+++ b/app/presenters/assertion_browse_row_presenter.rb
@@ -9,6 +9,7 @@ class AssertionBrowseRowPresenter
       summary: @assertion.summary,
       gene_name: @assertion.gene_name,
       gene_id: @assertion.gene_id,
+      gene_entrez_id: @assertion.gene_entrez_id,
       disease: @assertion.disease_name,
       variant_name: @assertion.variant_name,
       variant_id: @assertion.variant_id,

--- a/app/presenters/evidence_item_browse_row_presenter.rb
+++ b/app/presenters/evidence_item_browse_row_presenter.rb
@@ -9,6 +9,7 @@ class EvidenceItemBrowseRowPresenter
       description: @evidence_item.description,
       gene_name: @evidence_item.gene_name,
       gene_id: @evidence_item.gene_id,
+      gene_entrez_id: @evidence_item.gene_entrez_id,
       disease: @evidence_item.disease_name,
       drugs: @evidence_item.drug_names,
       variant_name: @evidence_item.variant_name,


### PR DESCRIPTION
This is meant to address griffithlab/civic-client#1019, wherein the Entrez ID is ending up in the URL where the Gene ID should be.  The result of that is a page where the displayed gene doesn't match the variant and evidence item information.

This PR is currently proactively changing the assertion browse query, too, even though that page is not using the Gene ID.

(I guess there's nothing to stop someone from crafting all sorts of zany URLs that mix genes, variants, and evidence that don't go together like https://civicdb.org/events/genes/2260/summary/variants/12/summary/evidence/1427/summary#evidence -- but at least now we're not doing it!)

