### PR TITLE
Include source type in source display name

### DIFF
--- a/app/models/source.rb
+++ b/app/models/source.rb
@@ -37,7 +37,18 @@ class Source < ActiveRecord::Base
   end
 
   def display_name
-    description
+    "#{self.description} - (#{source_type_description})"
+  end
+
+  def source_type_description
+    case self.source_type
+    when 'ASCO'
+      'ASCO Abstract'
+    when 'PubMed'
+      'PubMed'
+    else
+      ''
+    end
   end
 
   def source_url


### PR DESCRIPTION
This will cause it to appear in the diffs for revisions.
Closes griffithlab/civic-client#1020

Here's how it looks: 
<img width="1082" alt="screen shot 2019-01-09 at 10 40 14 am" src="https://user-images.githubusercontent.com/13370/50914045-5842c280-13fb-11e9-931d-32ace33cc2fa.png">
