### PR TITLE
Manually specify ndex dependencies for python 3

### DIFF
--- a/lib/capistrano/tasks/dependencies.rake
+++ b/lib/capistrano/tasks/dependencies.rake
@@ -3,7 +3,7 @@ namespace :dependencies do
   task :python do
     on roles(:all) do
       execute "sudo apt-get -y install python python3-pip"
-      execute :pip3, "install ndexutil -r #{current_path}/misc_scripts/ndex_requirements.txt --no-deps"
+      execute :pip3, "install ndexutil -r #{current_path}/misc_scripts/ndex_requirements.txt --no-cache-dir --no-deps"
     end
   end
 end

--- a/misc_scripts/ndex_process_civic.py
+++ b/misc_scripts/ndex_process_civic.py
@@ -3,6 +3,7 @@ import pandas as pd
 import ndexutil.tsv.tsv2nicecx2 as t2n
 import argparse
 import jsonschema
+import datetime
 from os import path
 import ndex2.client as nc
 
@@ -566,6 +567,8 @@ def run_loading(params):
                     network.set_network_attribute('description', params.get('net_description'))
                 else:
                     network.set_network_attribute(name='description', values=v)
+            elif k.upper() == 'VERSION':
+                network.set_network_attribute(name='version', values=datetime.datetime.now().strftime("%Y-%m-%d"))
             else:
                 network.set_network_attribute(name=k, values=v)
 

--- a/misc_scripts/ndex_requirements.txt
+++ b/misc_scripts/ndex_requirements.txt
@@ -1,9 +1,15 @@
-ndex2
+decorator
+python-dateutil
+certifi
+ijson
+enum34
 requests
 requests_toolbelt
 networkx==1.11
 urllib3>=1.16
 pandas
-enum34
 jsonschema
 gspread
+numpy
+ndex2
+


### PR DESCRIPTION
Talked with @susannasiebert about this today - to work around a python 2 vs 3 issue, manually specify additional dependencies in our requirements.txt