### PR TITLE
Curators can reject their own submitted evidence

### DIFF
--- a/app/policies/assertion_policy.rb
+++ b/app/policies/assertion_policy.rb
@@ -16,6 +16,6 @@ class AssertionPolicy < Struct.new(:user, :assertion)
   end
 
   def reject?
-    Role.user_is_at_least_a?(user, :editor)
+    Role.user_is_at_least_a?(user, :editor) || assertion.submitter == user
   end
 end

--- a/app/policies/evidence_item_policy.rb
+++ b/app/policies/evidence_item_policy.rb
@@ -16,6 +16,6 @@ class EvidenceItemPolicy < Struct.new(:user, :evidence_item)
   end
 
   def reject?
-    Role.user_is_at_least_a?(user, :editor)
+    Role.user_is_at_least_a?(user, :editor) || evidence_item.submitter == user
   end
 end


### PR DESCRIPTION
Previously only an editor could reject evidence. With this change,
curators can reject evidence too, but only evidence they themselves
submitted.

Along with https://github.com/griffithlab/civic-client/tree/feature/misc-fixes this closes griffithlab/civic-client#1037