### PR TITLE
Remove nil value from variant's drugs array

### DIFF
--- a/app/presenters/variant_browse_row_presenter.rb
+++ b/app/presenters/variant_browse_row_presenter.rb
@@ -13,7 +13,7 @@ class VariantBrowseRowPresenter
       diseases: @variant.disease_names,
       evidence_item_count: @variant.evidence_item_count,
       assertion_count: @variant.assertion_count,
-      drugs: @variant.drug_names,
+      drugs: @variant.drug_names.compact,
       civic_actionability_score: @variant.civic_actionability_score,
     }
   end


### PR DESCRIPTION
The array_agg aggregation function we use in the
`app/datatables/variant_browse_table.rb` `select_query` doesn't remove nil
values, which happens for variants that have evidence items that don't
have a drug.

Closes https://github.com/griffithlab/civic-client/issues/1030#issuecomment-458627346