### PR TITLE
Fix bug that allowed duplicate sources to be created for a source suggestion

### DIFF
--- a/app/admin/utilities.rb
+++ b/app/admin/utilities.rb
@@ -150,12 +150,19 @@ ActiveAdmin.register_page 'Utilities' do
                "No Source Type provided."
              elsif (source = Source.find_by(citation_id: proposed_citation_id, source_type: proposed_source_type_int))
                "Source '#{source.description}' already present."
-             elsif proposed_source_type == 'pubmed'
+             elsif proposed_source_type == 'PubMed'
                if (citation = Scrapers::PubMed.get_citation_from_pubmed_id(proposed_citation_id)).present?
                  Source.create(citation_id: proposed_citation_id, description: citation, source_type: proposed_source_type)
                  "Source '#{citation}' added to CIViC."
                else
                  "Source with PubMed Id #{proposed_citation_id} not found or PubMed is unreachable."
+               end
+             elsif proposed_source_type == 'ASCO'
+               if (citation = Scrapers::Asco.get_citation_from_asco_id(proposed_citation_id)).present?
+                 Source.create(citation_id: proposed_citation_id, description: citation, source_type: proposed_source_type)
+                 "Source '#{citation}' added to CIViC."
+               else
+                 "Source with ASCO Id #{proposed_citation_id} not found or ASCO is unreachable."
                end
              else
                "Source type not supported."

--- a/app/admin/utilities.rb
+++ b/app/admin/utilities.rb
@@ -143,11 +143,12 @@ ActiveAdmin.register_page 'Utilities' do
   page_action :add_source, method: :post do
     proposed_citation_id = params[:citation_id] && params[:citation_id].strip
     proposed_source_type = params[:source_type] && params[:source_type].strip
+    proposed_source_type_int = Source.source_types[proposed_source_type]
     notice = if proposed_citation_id.blank?
                "No Source Id provided."
              elsif proposed_source_type.blank?
                "No Source Type provided."
-             elsif (source = Source.find_by(citation_id: proposed_citation_id, source_type: proposed_source_type))
+             elsif (source = Source.find_by(citation_id: proposed_citation_id, source_type: proposed_source_type_int))
                "Source '#{source.description}' already present."
              elsif proposed_source_type == 'pubmed'
                if (citation = Scrapers::PubMed.get_citation_from_pubmed_id(proposed_citation_id)).present?

--- a/app/controllers/sources_controller.rb
+++ b/app/controllers/sources_controller.rb
@@ -88,7 +88,8 @@ class SourcesController < ApplicationController
   def existence
     proposed_citation_id = params[:citation_id]
     proposed_source_type = params[:source_type] || 'PubMed'
-    (to_render, status) = if source = Source.find_by(citation_id: proposed_citation_id, source_type: proposed_source_type)
+    proposed_source_type_int = Source.source_types[proposed_source_type]
+    (to_render, status) = if source = Source.find_by(citation_id: proposed_citation_id, source_type: proposed_source_type_int)
       [{ citation: source.description, citation_id: source.citation_id, source_type: source.source_type, status: source.status}, :ok]
     elsif proposed_source_type == 'PubMed'
       if (citation = Scrapers::PubMed.get_citation_from_pubmed_id(proposed_citation_id)).present?

--- a/app/models/actions/propose_evidence_item.rb
+++ b/app/models/actions/propose_evidence_item.rb
@@ -54,7 +54,8 @@ module Actions
     def get_source(params)
       source_type = params[:source][:source_type]
       citation_id = params[:source][:citation_id]
-      if found_source = Source.find_by(citation_id: citation_id, source_type: source_type)
+      source_type_int = Source.source_types[source_type]
+      if found_source = Source.find_by(citation_id: citation_id, source_type: source_type_int)
         found_source
       else
         Source.new(citation_id: citation_id, source_type: source_type).tap do |source|

--- a/app/models/actions/suggest_publication.rb
+++ b/app/models/actions/suggest_publication.rb
@@ -32,7 +32,8 @@ module Actions
     end
 
     def set_source
-      if existing_source = Source.find_by(citation_id: citation_id, source_type: source_type)
+      source_type_int = Source.source_types[source_type]
+      if existing_source = Source.find_by(citation_id: citation_id, source_type: source_type_int)
         @source = existing_source
       else
         if source_type == 'PubMed'

--- a/app/models/source.rb
+++ b/app/models/source.rb
@@ -71,8 +71,9 @@ class Source < ActiveRecord::Base
   end
 
   def self.get_sources_from_list(citation_ids, source_type='PubMed')
+    source_type_int = Source.source_types[source_type]
     citation_ids.map do |citation_id|
-      if (source = Source.find_by(citation_id: citation_id, source_type: source_type))
+      if (source = Source.find_by(citation_id: citation_id, source_type: source_type_int))
         source
       elsif source_type == 'PubMed'
         if (citation = Scrapers::PubMed.get_citation_from_pubmed_id(citation_id))


### PR DESCRIPTION
The query as it was previously written would always return `nil` because it would search with the source_type string instead of the underlying integer. This would result in a new source to always get created when making a source suggestion, even if that source already existed in our database.