### PR TITLE
Decode HTML characters in ASCO abstract text

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ gem 'staccato', '~> 0.4.7'
 gem 'rack-rewrite'
 gem 'paperclip', '~> 5.1.0'
 gem 'rack-cors', '~> 1.0.2', require: 'rack/cors'
+gem 'htmlentities'
 
 gem 'omniauth', '~> 1.8.1'
 gem 'omniauth-facebook', '~> 1.6.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -151,6 +151,7 @@ GEM
       activesupport (>= 3.2, < 5)
     hashie (3.5.7)
     hike (1.2.3)
+    htmlentities (4.3.4)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
     inherited_resources (1.6.0)
@@ -390,6 +391,7 @@ DEPENDENCIES
   diffy (~> 3.0.7)
   fabrication
   gravatarify (~> 3.0.0)
+  htmlentities
   jbuilder (~> 2.0)
   kaminari (~> 0.16.1)
   launchy

--- a/lib/scrapers/asco_record_response.rb
+++ b/lib/scrapers/asco_record_response.rb
@@ -1,3 +1,5 @@
+require 'htmlentities'
+
 module Scrapers
   class AscoRecordResponse
     attr_reader :json
@@ -27,7 +29,8 @@ module Scrapers
 
     def abstract
       sanitizer = Rails::Html::FullSanitizer.new
-      sanitizer.sanitize(json['Body']).strip
+      decoder = HTMLEntities.new
+      decoder.decode(sanitizer.sanitize(json['Body']).strip)
     end
   end
 end


### PR DESCRIPTION
The ASCO API returns special characters as hex code, e.g. `&#x2264;` for `≤` and `&#x003E;` for `>`. We parse the abstract text through `Rails::Html::FullSanitizer` and while that resolves the first one correctly, it resolves the second one as `&gt;`. `HTMLEntities` will take care to decode those characters correctly.

Closes https://github.com/griffithlab/civic-client/issues/1069.