### PR TITLE
Refactor the UpdateAlleleRegistryIds job and add new SetAlleleRegistryIds

### DIFF
--- a/app/jobs/allele_registry_ids.rb
+++ b/app/jobs/allele_registry_ids.rb
@@ -1,0 +1,47 @@
+require 'rbconfig'
+
+class AlleleRegistryIds < ActiveJob::Base
+  def add_allele_registry_link(allele_registry_id)
+    system("#{ruby_executable} #{script_path} put \"reg.genome.network/allele/#{allele_registry_id}/externalSource/civic\" \"p1=#{allele_registry_id}\" #{allele_registry_username} #{allele_registry_password}")
+  end
+
+  def ruby_executable
+    RbConfig.ruby
+  end
+
+  def script_path
+    File.join(Rails.root, 'misc_scripts', 'add_allele_registry_link.rb')
+  end
+
+  def get_allele_registry_id(variant)
+    response = response(variant)
+    JSON.parse(response)['@id'].split('/')[-1] rescue nil
+  end
+
+  def response(variant)
+    if hgvs = HgvsExpression.allele_registry_hgvs(variant)
+      make_request(hgvs)
+    else
+      {}
+    end
+  end
+
+  private
+  def make_request(hgvs)
+    Scrapers::Util.make_get_request(allele_registry_url(hgvs))
+  rescue StandardError
+    {}
+  end
+
+  def allele_registry_url(coordinate_string)
+    URI.encode("http://reg.genome.network/allele?hgvs=#{coordinate_string}")
+  end
+
+  def allele_registry_username
+    ENV['ALLELE_REGISTRY_USERNAME'] || Rails.application.secrets.allele_registry_username
+  end
+
+  def allele_registry_password
+    ENV['ALLELE_REGISTRY_PASSWORD'] || Rails.application.secrets.allele_registry_password
+  end
+end

--- a/app/jobs/allele_registry_ids.rb
+++ b/app/jobs/allele_registry_ids.rb
@@ -1,6 +1,10 @@
 require 'rbconfig'
 
 class AlleleRegistryIds < ActiveJob::Base
+  def delete_allele_registry_link(allele_registry_id)
+    system("#{ruby_executable} #{script_path} delete \"reg.genome.network/allele/#{allele_registry_id}/externalSource/civic\" \"p1=#{allele_registry_id}\" #{allele_registry_username} #{allele_registry_password}")
+  end
+
   def add_allele_registry_link(allele_registry_id)
     system("#{ruby_executable} #{script_path} put \"reg.genome.network/allele/#{allele_registry_id}/externalSource/civic\" \"p1=#{allele_registry_id}\" #{allele_registry_username} #{allele_registry_password}")
   end

--- a/app/jobs/set_allele_registry_ids.rb
+++ b/app/jobs/set_allele_registry_ids.rb
@@ -1,0 +1,25 @@
+require 'rbconfig'
+
+class SetAlleleRegistryIds < AlleleRegistryIds
+  def perform(recurring = true)
+    begin
+      for v in Variant.where(allele_registry_id: nil) do
+        allele_registry_id = get_allele_registry_id(v)
+        v.allele_registry_id = allele_registry_id
+        v.save
+        add_allele_registry_link(allele_registry_id)
+      end
+    ensure
+      reschedule if recurring
+    end
+  end
+
+  def reschedule
+    self.class.set(wait_until: next_day).perform_later
+  end
+
+  def next_day
+    Date.tomorrow
+      .midnight
+  end
+end

--- a/app/jobs/set_allele_registry_ids.rb
+++ b/app/jobs/set_allele_registry_ids.rb
@@ -3,7 +3,7 @@ require 'rbconfig'
 class SetAlleleRegistryIds < AlleleRegistryIds
   def perform(recurring = true)
     begin
-      for v in Variant.where(allele_registry_id: nil) do
+      Variant.where(allele_registry_id: nil).each do |v|
         allele_registry_id = get_allele_registry_id(v)
         v.allele_registry_id = allele_registry_id
         v.save

--- a/app/jobs/update_allele_registry_ids.rb
+++ b/app/jobs/update_allele_registry_ids.rb
@@ -11,7 +11,7 @@ class UpdateAlleleRegistryIds < AlleleRegistryIds
           v.save
           add_allele_registry_link(allele_registry_id)
           #delete the linkout if no other variant has this allele registry ID
-          if Variant.find_by(allele_registry_id: old_allele_registry_id).exists?
+          if Variant.where(allele_registry_id: old_allele_registry_id).exists?
               delete_allele_registry_link(old_allele_registry_id)
           end
         end

--- a/app/jobs/update_allele_registry_ids.rb
+++ b/app/jobs/update_allele_registry_ids.rb
@@ -3,7 +3,7 @@ require 'rbconfig'
 class UpdateAlleleRegistryIds < AlleleRegistryIds
   def perform(recurring = true)
     begin
-      for v in Variant.where.not(allele_registry_id: nil) do
+      Variant.where.not(allele_registry_id: nil).each do |v|
         old_allele_registry_id = v.allele_registry_id
         allele_registry_id = get_allele_registry_id(v)
         if allele_registry_id != old_allele_registry_id

--- a/app/jobs/update_allele_registry_ids.rb
+++ b/app/jobs/update_allele_registry_ids.rb
@@ -11,7 +11,7 @@ class UpdateAlleleRegistryIds < AlleleRegistryIds
           v.save
           add_allele_registry_link(allele_registry_id)
           #delete the linkout if no other variant has this allele registry ID
-          if Variant.find_by(allele_registry_id: old_allele_registry_id).blank?
+          if Variant.find_by(allele_registry_id: old_allele_registry_id).exists?
               delete_allele_registry_link(old_allele_registry_id)
           end
         end

--- a/app/jobs/update_allele_registry_ids.rb
+++ b/app/jobs/update_allele_registry_ids.rb
@@ -4,17 +4,23 @@ class UpdateAlleleRegistryIds < AlleleRegistryIds
   def perform(recurring = true)
     begin
       for v in Variant.where.not(allele_registry_id: nil) do
+        old_allele_registry_id = v.allele_registry_id
         allele_registry_id = get_allele_registry_id(v)
-        if allele_registry_id != v.allele_registry_id
+        if allele_registry_id != old_allele_registry_id
           v.allele_registry_id = allele_registry_id
           v.save
           add_allele_registry_link(allele_registry_id)
+          #delete the linkout if no other variant has this allele registry ID
+          if Variant.find_by(allele_registry_id: old_allele_registry_id).blank?
+              delete_allele_registry_link(old_allele_registry_id)
+          end
         end
       end
     ensure
       reschedule if recurring
     end
   end
+
   def reschedule
     self.class.set(wait_until: next_week).perform_later
   end

--- a/app/jobs/update_allele_registry_ids.rb
+++ b/app/jobs/update_allele_registry_ids.rb
@@ -1,72 +1,28 @@
 require 'rbconfig'
 
-class UpdateAlleleRegistryIds < ActiveJob::Base
+class UpdateAlleleRegistryIds < AlleleRegistryIds
   def perform(recurring = true)
     begin
-      for v in Variant.where(allele_registry_id: nil) do
-        allele_registry_id = get_allele_registry_id(v)
-        v.allele_registry_id = allele_registry_id
-        v.save
-      end
       for v in Variant.where.not(allele_registry_id: nil) do
         allele_registry_id = get_allele_registry_id(v)
-        add_allele_registry_link(allele_registry_id)
+        if allele_registry_id != v.allele_registry_id
+          v.allele_registry_id = allele_registry_id
+          v.save
+          add_allele_registry_link(allele_registry_id)
+        end
       end
     ensure
       reschedule if recurring
     end
   end
-
-  def add_allele_registry_link(allele_registry_id)
-    system("#{ruby_executable} #{script_path} put \"reg.genome.network/allele/#{allele_registry_id}/externalSource/civic\" \"p1=#{allele_registry_id}\" #{allele_registry_username} #{allele_registry_password}")
-  end
-
-  def ruby_executable
-    RbConfig.ruby
-  end
-
-  def script_path
-    File.join(Rails.root, 'misc_scripts', 'add_allele_registry_link.rb')
-  end
-
   def reschedule
-    self.class.set(wait_until: next_day).perform_later
+    self.class.set(wait_until: next_week).perform_later
   end
 
-  def next_day
-    Date.tomorrow
+  def next_week
+    Date.today
+      .beginning_of_week
+      .next_week
       .midnight
-  end
-
-  def get_allele_registry_id(variant)
-    response = response(variant)
-    JSON.parse(response)['@id'].split('/')[-1] rescue nil
-  end
-
-  def response(variant)
-    if hgvs = HgvsExpression.allele_registry_hgvs(variant)
-      make_request(hgvs)
-    else
-      {}
-    end
-  end
-
-  private
-  def make_request(hgvs)
-    Scrapers::Util.make_get_request(allele_registry_url(hgvs))
-  rescue StandardError
-    {}
-  end
-
-  def allele_registry_url(coordinate_string)
-    URI.encode("http://reg.genome.network/allele?hgvs=#{coordinate_string}")
-  end
-
-  def allele_registry_username
-    ENV['ALLELE_REGISTRY_USERNAME'] || Rails.application.secrets.allele_registry_username
-  end
-
-  def allele_registry_password
-    ENV['ALLELE_REGISTRY_PASSWORD'] || Rails.application.secrets.allele_registry_password
   end
 end


### PR DESCRIPTION
The UpdateAlleleRegistryIDs job now correctly updates the allele registry ID on a variant where it changed (e.g. if the coordinates were updated) and only makes the post request to the allele registry API if the ID changed. This occurs weekly to reduce the number of requests to their API. We might be able to get away with running it daily if we don't expect this to happen very often.

This PR also add a SetAlleleRegistryIds job which runs daily to initially set the allele registry ID for new variants.

I'm in contact with Ronak on how to remove reverse linkouts for allele registry IDs we no longer match (e.g. after a variant's coordinates were updated)