### PR TITLE
Support gene names in the direct linking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
 language: ruby
+services:
+  - postgresql
+addons:
+  postgresql: '9.6'
 script:
   - mkdir -p tmp/{cache,sessions}
   - bundle exec rake db:create

--- a/app/models/frontend_router.rb
+++ b/app/models/frontend_router.rb
@@ -28,8 +28,10 @@ class FrontendRouter
       [ Variant, :id, ]
     when /evidence/, /evidence_items?/
       [ EvidenceItem, :id, ]
-    when /entrez/
+    when /entrez_id/
       [ Gene, :entrez_id, ]
+    when /entrez_name/
+      [ Gene, :name , ]
     when /variant_groups?/
       [ VariantGroup, :id, ]
     when /revisions?/


### PR DESCRIPTION
Closes https://github.com/griffithlab/civic-client/issues/1118

This adds support for direct linking to genes by their entrez gene name using the civicdb.org/links/entrez_name/:name URL format. Special characters of the gene name (like `/`) will need to be URL-encoded.