### PR TITLE
Clone subscriptions

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 The Genome Institute
+Copyright (c) 2019 Washington University
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/app/admin/utilities.rb
+++ b/app/admin/utilities.rb
@@ -2,10 +2,10 @@ ActiveAdmin.register_page 'Utilities' do
   menu priority: 10, label: 'Utilities'
 
   content title: 'CIViC Utilities' do
+  all_users = User.all.sort_by(&:display_name)
     columns do
       column do
         panel "Merge Users" do
-          all_users = User.all.sort_by(&:display_name)
           form id: :merge_users_form do |f|
             f.label "User to keep:"
             f.select :user_to_keep, name: :user_to_keep, form: :merge_users_form do
@@ -71,6 +71,27 @@ ActiveAdmin.register_page 'Utilities' do
             f.br
             f.br
             f.button "Merge", formmethod: :post, form: 'merge_drugs_form', formaction: admin_utilities_merge_drugs_path, type: 'submit'
+          end
+        end
+        panel "Copy Subscriptions" do
+          form id: :copy_subscriptions_form do |f|
+            f.label "User to copy from:"
+            f.select :from_user, name: :from_user, form: :copy_subscriptions_form do
+              all_users.each do |user|
+                f.option "#{user.display_name} (#{user.email}), #{user.id})", value: user.id
+              end
+            end
+            f.br
+            f.br
+            f.label "User to copy to:"
+            f.select :to_user, name: :to_user, form: :copy_subscriptions_form do
+              all_users.each do |user|
+                f.option "#{user.display_name} (#{user.email}), #{user.id})", value: user.id
+              end
+            end
+            f.br
+            f.br
+            f.button "Copy", formmethod: :post, form: 'copy_subscriptions_form', formaction: admin_utilities_copy_subscriptions_path, type: 'submit'
           end
         end
       end
@@ -237,6 +258,20 @@ ActiveAdmin.register_page 'Utilities' do
                end
                drug_to_remove.destroy
                "Drugs Merged"
+             end
+
+    redirect_to admin_utilities_path, notice: notice
+  end
+
+  page_action :copy_subscriptions, method: :post do
+    from_user = User.find(params[:from_user])
+    to_user = User.find(params[:to_user])
+
+    notice = if from_user == to_user
+               "Cannot copy subscriptions to the same user"
+             else
+               CloneSubscriptions.new.perform(from_user, to_user)
+               "Subscriptions Copied"
              end
 
     redirect_to admin_utilities_path, notice: notice

--- a/app/jobs/clone_subscriptions.rb
+++ b/app/jobs/clone_subscriptions.rb
@@ -1,0 +1,35 @@
+class CloneSubscriptions < ActiveJob::Base
+  attr_reader :from_user, :to_user
+
+  def perform(from_user, to_user)
+    @from_user = from_user
+    @to_user = to_user
+
+    ActiveRecord::Base.transaction do
+      copy_subscriptions
+    end
+  end
+
+  private
+  def copy_subscriptions
+    subscriptions_to_copy = from_user.subscriptions
+    existing_subscriptions = to_user.subscriptions
+      .map { |s| key_for_subscription(s) }
+      .to_set
+
+
+    subscriptions_to_copy.each do |sub|
+      unless existing_subscriptions.include?(key_for_subscription(sub))
+        new_sub = sub.dup
+        new_sub.user = to_user
+        new_sub.type = 'OnSiteSubscription'
+        new_sub.save
+        existing_subscriptions << key_for_subscription(new_sub)
+      end
+    end
+  end
+
+  def key_for_subscription(s)
+    "#{s.subscribable_id}_#{s.subscribable_type}" 
+  end
+end

--- a/spec/jobs/clone_subscriptions_spec.rb
+++ b/spec/jobs/clone_subscriptions_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+require 'rails_helper'
+
+describe 'cloning subscriptions' do
+
+  before :each do
+    @to_user = Fabricate(:user)
+    @from_user = Fabricate(:user)
+    @gene = Fabricate(:gene)
+    @gene2 = Fabricate(:gene)
+    @variant = Fabricate(:variant)
+  end
+
+  it 'should copy subscriptions from one user to the other' do
+    OnSiteSubscription.create(user: @from_user, subscribable: @gene)
+    OnSiteSubscription.create(user: @from_user, subscribable: @variant)
+    OnSiteSubscription.create(user: @to_user, subscribable: @gene2)
+
+    CloneSubscriptions.new.perform(@from_user, @to_user)
+
+    expect(@to_user.subscriptions.count).to eq(3)
+
+
+    from_subs = @from_user.subscriptions(true).map(&:subscribable).to_set
+    to_subs = @to_user.subscriptions(true).map(&:subscribable).to_set
+
+    expect(to_subs.superset? from_subs).to be true
+  end
+
+  it 'should not create duplicated subscriptions' do
+    OnSiteSubscription.create(user: @from_user, subscribable: @gene)
+    OnSiteSubscription.create(user: @from_user, subscribable: @variant)
+    OnSiteSubscription.create(user: @to_user, subscribable: @variant)
+    OnSiteSubscription.create(user: @to_user, subscribable: @gene2)
+
+    CloneSubscriptions.new.perform(@from_user, @to_user)
+
+    expect(@to_user.subscriptions.count).to eq(3)
+
+
+    from_subs = @from_user.subscriptions(true).map(&:subscribable).to_set
+    to_subs = @to_user.subscriptions(true).map(&:subscribable).to_set
+
+    expect(to_subs.superset? from_subs).to be true
+  end
+
+end
+


### PR DESCRIPTION
Introduce utility for cloning subscriptions.

On a call, Shruti mentioned that it would be nice to be able to
get notifications that would have gone to interns after the leave.
This will allow an admin to clone a user account's subscriptions to
another user's account, while not creating duplicate subscriptions.

closes griffithlab/civic-client#1149