### PR TITLE
Save _:CA allele registry entries as `unregistered`

### DIFF
--- a/app/jobs/set_allele_registry_ids.rb
+++ b/app/jobs/set_allele_registry_ids.rb
@@ -5,9 +5,14 @@ class SetAlleleRegistryIds < AlleleRegistryIds
     begin
       Variant.where(allele_registry_id: nil).each do |v|
         allele_registry_id = get_allele_registry_id(v)
-        v.allele_registry_id = allele_registry_id
-        v.save
-        add_allele_registry_link(allele_registry_id)
+        if allele_registry_id == '_:CA'
+          v.allele_registry_is = 'unregistered'
+          v.save
+        else
+          v.allele_registry_id = allele_registry_id
+          v.save
+          add_allele_registry_link(allele_registry_id)
+        end
       end
     ensure
       reschedule if recurring

--- a/app/jobs/update_allele_registry_ids.rb
+++ b/app/jobs/update_allele_registry_ids.rb
@@ -7,9 +7,14 @@ class UpdateAlleleRegistryIds < AlleleRegistryIds
         old_allele_registry_id = v.allele_registry_id
         allele_registry_id = get_allele_registry_id(v)
         if allele_registry_id != old_allele_registry_id
-          v.allele_registry_id = allele_registry_id
-          v.save
-          add_allele_registry_link(allele_registry_id)
+          if allele_registry_id == '_:CA'
+            v.allele_registry_is = 'unregistered'
+            v.save
+          else
+            v.allele_registry_id = allele_registry_id
+            v.save
+            add_allele_registry_link(allele_registry_id)
+          end
           #delete the linkout if no other variant has this allele registry ID
           unless Variant.where(allele_registry_id: old_allele_registry_id).exists?
               delete_allele_registry_link(old_allele_registry_id)

--- a/app/jobs/update_allele_registry_ids.rb
+++ b/app/jobs/update_allele_registry_ids.rb
@@ -17,7 +17,9 @@ class UpdateAlleleRegistryIds < AlleleRegistryIds
           end
           #delete the linkout if no other variant has this allele registry ID
           unless Variant.where(allele_registry_id: old_allele_registry_id).exists?
+            if old_allele_registry != '_:CA' and old_allele_registry != 'undefined'
               delete_allele_registry_link(old_allele_registry_id)
+            end
           end
         end
       end

--- a/app/jobs/update_allele_registry_ids.rb
+++ b/app/jobs/update_allele_registry_ids.rb
@@ -8,7 +8,7 @@ class UpdateAlleleRegistryIds < AlleleRegistryIds
         allele_registry_id = get_allele_registry_id(v)
         if allele_registry_id != old_allele_registry_id
           if allele_registry_id == '_:CA'
-            v.allele_registry_is = 'unregistered'
+            v.allele_registry_id = 'unregistered'
             v.save
           else
             v.allele_registry_id = allele_registry_id
@@ -17,7 +17,7 @@ class UpdateAlleleRegistryIds < AlleleRegistryIds
           end
           #delete the linkout if no other variant has this allele registry ID
           unless Variant.where(allele_registry_id: old_allele_registry_id).exists?
-            if old_allele_registry != '_:CA' and old_allele_registry != 'undefined'
+            if old_allele_registry_id != '_:CA' and old_allele_registry_id != 'undefined'
               delete_allele_registry_link(old_allele_registry_id)
             end
           end

--- a/app/jobs/update_allele_registry_ids.rb
+++ b/app/jobs/update_allele_registry_ids.rb
@@ -6,7 +6,7 @@ class UpdateAlleleRegistryIds < AlleleRegistryIds
       Variant.where.not(allele_registry_id: nil).each do |v|
         old_allele_registry_id = v.allele_registry_id
         allele_registry_id = get_allele_registry_id(v)
-        if allele_registry_id != old_allele_registry_id
+        if allele_registry_id != old_allele_registry_id || old_allele_registry_id == '_:CA'
           if allele_registry_id == '_:CA'
             v.allele_registry_id = 'unregistered'
             v.save

--- a/app/jobs/update_allele_registry_ids.rb
+++ b/app/jobs/update_allele_registry_ids.rb
@@ -11,7 +11,7 @@ class UpdateAlleleRegistryIds < AlleleRegistryIds
           v.save
           add_allele_registry_link(allele_registry_id)
           #delete the linkout if no other variant has this allele registry ID
-          if Variant.where(allele_registry_id: old_allele_registry_id).exists?
+          unless Variant.where(allele_registry_id: old_allele_registry_id).exists?
               delete_allele_registry_link(old_allele_registry_id)
           end
         end


### PR DESCRIPTION
This also adds some more checking about when we register and unregister the allele registry linkout and fixes a bug with deleting the linkout.

Prerequisite for https://github.com/griffithlab/civic-client/issues/1146