### PR TITLE
Use the EvidenceItemWithStateParamsPresenter instead of EvidenceItemIndexPresenter for the variant_groups/id/evidence_items endpoint

### DIFF
--- a/app/controllers/evidence_items_controller.rb
+++ b/app/controllers/evidence_items_controller.rb
@@ -45,7 +45,7 @@ class EvidenceItemsController < ApplicationController
     render json: PaginatedCollectionPresenter.new(
       variants,
       request,
-      EvidenceItemIndexPresenter,
+      EvidenceItemWithStateParamsPresenter,
       PaginationPresenter
     )
   end


### PR DESCRIPTION
the state_params have the required gene and variant info.

Prerequisite for griffithlab/civic-client#1147