### PR TITLE
Update sequence ontology file to scrape

### DIFF
--- a/app/jobs/update_sequence_ontology.rb
+++ b/app/jobs/update_sequence_ontology.rb
@@ -39,7 +39,7 @@ class UpdateSequenceOntology < ActiveJob::Base
   end
 
   def latest_soid_path
-    "https://github.com/The-Sequence-Ontology/SO-Ontologies/raw/master/releases/so-xp.owl/so-xp.obo"
+    "https://raw.githubusercontent.com/The-Sequence-Ontology/SO-Ontologies/master/releases/so-xp.owl/so.obo"
   end
 
   def next_week


### PR DESCRIPTION
The so-xp.obo file has been removed. As per https://github.com/The-Sequence-Ontology/SO-Ontologies/issues/473#issuecomment-517055874 the so.obo should be identical.