### PR TITLE
Limit drug name suggestions

### DIFF
--- a/app/models/drug_name_suggestion.rb
+++ b/app/models/drug_name_suggestion.rb
@@ -17,8 +17,11 @@ class DrugNameSuggestion
   end
 
   def self.get_local_suggestions(name)
-    Drug.where('name ILIKE :name', name: "%#{name}%")
+
+    Drug.where('name ILIKE :name', name: "%#{name}%", evidence_items: {status: 'accepted'})
+      .joins(:evidence_items)
       .limit(12)
+      .distinct
       .pluck(:name)
   end
 


### PR DESCRIPTION
Only return local name suggestions in the typeahead for drugs already
associated with an accepted evidence item.