### PR TITLE
Add `Dominant Negative` as a clinical significance option

### DIFF
--- a/app/const/constants.rb
+++ b/app/const/constants.rb
@@ -39,6 +39,7 @@ module Constants
     'Unaltered Function',
     'Neomorphic',
     'Unknown',
+    'Dominant Negative',
   ]
 
   DRUG_INTERACTION_TYPES = ['Combination', 'Sequential', 'Substitutes']


### PR DESCRIPTION
Prerequisite for https://github.com/griffithlab/civic-client/issues/1189