### PR TITLE
Update view to respect soft deletion

### DIFF
--- a/db/migrate/20191014213854_update_evidence_items_by_statuses_to_version_2.rb
+++ b/db/migrate/20191014213854_update_evidence_items_by_statuses_to_version_2.rb
@@ -1,0 +1,5 @@
+class UpdateEvidenceItemsByStatusesToVersion2 < ActiveRecord::Migration[5.2]
+  def change
+    update_view :evidence_items_by_statuses, version: 2, revert_to_version: 1
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_08_22_211502) do
+ActiveRecord::Schema.define(version: 2019_10_14_213854) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -204,8 +204,8 @@ ActiveRecord::Schema.define(version: 2019_08_22_211502) do
   create_table "comments", id: :serial, force: :cascade do |t|
     t.text "title", default: ""
     t.text "comment"
-    t.integer "commentable_id"
     t.string "commentable_type"
+    t.integer "commentable_id"
     t.integer "user_id"
     t.string "role", default: "comments"
     t.datetime "created_at"
@@ -279,8 +279,8 @@ ActiveRecord::Schema.define(version: 2019_08_22_211502) do
     t.text "description"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer "domain_of_expertise_id"
     t.string "domain_of_expertise_type"
+    t.integer "domain_of_expertise_id"
     t.integer "user_id"
     t.index ["description"], name: "index_domain_expert_tags_on_description"
     t.index ["domain_of_expertise_id", "domain_of_expertise_type"], name: "idx_domain_of_expertise"
@@ -321,8 +321,8 @@ ActiveRecord::Schema.define(version: 2019_08_22_211502) do
     t.text "action"
     t.text "description"
     t.integer "originating_user_id"
-    t.integer "subject_id"
     t.string "subject_type"
+    t.integer "subject_id"
     t.text "state_params"
     t.boolean "unlinkable", default: false
     t.integer "organization_id"
@@ -374,8 +374,8 @@ ActiveRecord::Schema.define(version: 2019_08_22_211502) do
   create_table "flags", id: :serial, force: :cascade do |t|
     t.integer "flagging_user_id"
     t.integer "resolving_user_id"
-    t.integer "flaggable_id"
     t.string "flaggable_type"
+    t.integer "flaggable_id"
     t.text "state"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -465,7 +465,7 @@ ActiveRecord::Schema.define(version: 2019_08_22_211502) do
     t.text "description"
     t.string "profile_image_file_name"
     t.string "profile_image_content_type"
-    t.integer "profile_image_file_size"
+    t.bigint "profile_image_file_size"
     t.datetime "profile_image_updated_at"
     t.integer "parent_id"
   end
@@ -552,8 +552,8 @@ ActiveRecord::Schema.define(version: 2019_08_22_211502) do
 
   create_table "subscriptions", id: :serial, force: :cascade do |t|
     t.integer "user_id"
-    t.integer "subscribable_id"
     t.string "subscribable_type"
+    t.integer "subscribable_id"
     t.string "type"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -566,8 +566,8 @@ ActiveRecord::Schema.define(version: 2019_08_22_211502) do
 
   create_table "suggested_changes", id: :serial, force: :cascade do |t|
     t.text "suggested_changes", null: false
-    t.integer "moderated_id"
     t.string "moderated_type"
+    t.integer "moderated_id"
     t.integer "user_id", null: false
     t.string "status", default: "new", null: false
     t.datetime "created_at"
@@ -608,7 +608,7 @@ ActiveRecord::Schema.define(version: 2019_08_22_211502) do
     t.text "affiliation"
     t.string "profile_image_file_name"
     t.string "profile_image_content_type"
-    t.integer "profile_image_file_size"
+    t.bigint "profile_image_file_size"
     t.datetime "profile_image_updated_at"
     t.integer "country_id"
     t.index ["country_id"], name: "index_users_on_country_id"
@@ -776,7 +776,7 @@ ActiveRecord::Schema.define(version: 2019_08_22_211502) do
               ELSE 0
           END) AS submitted_count
      FROM (variants v
-       JOIN evidence_items ei ON ((v.id = ei.variant_id)))
+       JOIN evidence_items ei ON (((v.id = ei.variant_id) AND (ei.deleted = false))))
     GROUP BY v.id;
   SQL
 end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -503,8 +503,8 @@ CREATE TABLE public.comments (
     id integer NOT NULL,
     title text DEFAULT ''::character varying,
     comment text,
-    commentable_id integer,
     commentable_type character varying,
+    commentable_id integer,
     user_id integer,
     role character varying DEFAULT 'comments'::character varying,
     created_at timestamp without time zone,
@@ -782,8 +782,8 @@ CREATE TABLE public.domain_expert_tags (
     description text,
     created_at timestamp without time zone,
     updated_at timestamp without time zone,
-    domain_of_expertise_id integer,
     domain_of_expertise_type character varying,
+    domain_of_expertise_id integer,
     user_id integer
 );
 
@@ -924,8 +924,8 @@ CREATE TABLE public.events (
     action text,
     description text,
     originating_user_id integer,
-    subject_id integer,
     subject_type character varying,
+    subject_id integer,
     state_params text,
     unlinkable boolean DEFAULT false,
     organization_id integer,
@@ -1033,7 +1033,7 @@ CREATE VIEW public.evidence_items_by_statuses AS
             ELSE 0
         END) AS submitted_count
    FROM (public.variants v
-     JOIN public.evidence_items ei ON ((v.id = ei.variant_id)))
+     JOIN public.evidence_items ei ON (((v.id = ei.variant_id) AND (ei.deleted = false))))
   GROUP BY v.id;
 
 
@@ -1075,8 +1075,8 @@ CREATE TABLE public.flags (
     id integer NOT NULL,
     flagging_user_id integer,
     resolving_user_id integer,
-    flaggable_id integer,
     flaggable_type character varying,
+    flaggable_id integer,
     state text,
     created_at timestamp without time zone,
     updated_at timestamp without time zone
@@ -1321,7 +1321,7 @@ CREATE TABLE public.organizations (
     description text,
     profile_image_file_name character varying,
     profile_image_content_type character varying,
-    profile_image_file_size integer,
+    profile_image_file_size bigint,
     profile_image_updated_at timestamp without time zone,
     parent_id integer
 );
@@ -1581,8 +1581,8 @@ CREATE TABLE public.sources_variants (
 CREATE TABLE public.subscriptions (
     id integer NOT NULL,
     user_id integer,
-    subscribable_id integer,
     subscribable_type character varying,
+    subscribable_id integer,
     type character varying,
     created_at timestamp without time zone,
     updated_at timestamp without time zone,
@@ -1618,8 +1618,8 @@ ALTER SEQUENCE public.subscriptions_id_seq OWNED BY public.subscriptions.id;
 CREATE TABLE public.suggested_changes (
     id integer NOT NULL,
     suggested_changes text NOT NULL,
-    moderated_id integer,
     moderated_type character varying,
+    moderated_id integer,
     user_id integer NOT NULL,
     status character varying DEFAULT 'new'::character varying NOT NULL,
     created_at timestamp without time zone,
@@ -1708,7 +1708,7 @@ CREATE TABLE public.users (
     affiliation text,
     profile_image_file_name character varying,
     profile_image_content_type character varying,
-    profile_image_file_size integer,
+    profile_image_file_size bigint,
     profile_image_updated_at timestamp without time zone,
     country_id integer
 );
@@ -2492,6 +2492,14 @@ ALTER TABLE ONLY public.pipeline_types
 
 ALTER TABLE ONLY public.regulatory_agencies
     ADD CONSTRAINT regulatory_agencies_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: schema_migrations schema_migrations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.schema_migrations
+    ADD CONSTRAINT schema_migrations_pkey PRIMARY KEY (version);
 
 
 --
@@ -3457,13 +3465,6 @@ CREATE INDEX index_variants_on_variant_bases ON public.variants USING btree (var
 
 
 --
--- Name: unique_schema_migrations; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE UNIQUE INDEX unique_schema_migrations ON public.schema_migrations USING btree (version);
-
-
---
 -- Name: user_index; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -3982,6 +3983,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20181114141145'),
 ('20181116152712'),
 ('20190822211502'),
-('201909062411');
+('201909062411'),
+('20191014213854');
 
 

--- a/db/views/evidence_items_by_statuses_v02.sql
+++ b/db/views/evidence_items_by_statuses_v02.sql
@@ -1,0 +1,8 @@
+SELECT
+  v.id AS variant_id,
+  SUM(CASE WHEN ei.status = 'accepted' THEN 1 ELSE 0 END) AS accepted_count,
+  SUM(CASE WHEN ei.status = 'rejected' THEN 1 ELSE 0 END) AS rejected_count,
+  SUM(CASE WHEN ei.status = 'submitted' THEN 1 ELSE 0 END) AS submitted_count
+FROM variants v
+INNER JOIN evidence_items ei ON v.id = ei.variant_id AND ei.deleted = 'f'
+GROUP BY v.id;


### PR DESCRIPTION
When we implemented soft deletion, the filtering out of deleted items happens automatically when we build our ActiveRecord queries. For this one particular aggregation we use a SQL view directly rather than going through ActiveRecord to build the query. As a result, this was not respecting the deleted flag and counts were getting thrown off.

closes #542 
closes griffithlab/civic-client#1217