### PR TITLE
Add many-to-many relationship from drugs to assertions

### DIFF
--- a/app/models/drug.rb
+++ b/app/models/drug.rb
@@ -3,6 +3,7 @@ class Drug < ActiveRecord::Base
   include WithCapitalizedName
 
   has_and_belongs_to_many :evidence_items
+  has_and_belongs_to_many :assertions
   has_and_belongs_to_many :drug_aliases
 
   def self.get_drugs_from_list(names)


### PR DESCRIPTION
Right now you can't do `drug1.assertions` because this relationship isn't defined.