### PR TITLE
Install python3.7 instead of 3.5 default

### DIFF
--- a/lib/capistrano/tasks/dependencies.rake
+++ b/lib/capistrano/tasks/dependencies.rake
@@ -2,7 +2,11 @@ namespace :dependencies do
   desc 'Install python dependencies'
   task :python do
     on roles(:all) do
-      execute "sudo apt-get -y install python python3-pip"
+      execute "sudo apt-get update"
+      execute "sudo apt-get -y install software-properties-common"
+      execute "sudo add-apt-repository ppa:deadsnakes/ppa"
+      execute "sudo apt-get update"
+      execute "sudo apt-get -y install python3.7 python3-pip"
       execute :pip3, "install ndexutil -r #{current_path}/misc_scripts/ndex_requirements.txt --no-cache-dir --no-deps"
       execute :pip3, "install civicpy==1.0.0rc2"
     end


### PR DESCRIPTION
For a box that doesn't have python3 installed yet, this should work fine. Because our boxes already had python 3.5 installed, I need to do the following steps to point python3 to python 3.7:
```
sudo rm /usr/bin/python3
sudo ln -s /usr/bin/python3.7 /usr/bin/python3
```
After this python3.7 was unable to find python3-apt, which was causing problems with re-running the cap dependency task. This was resolved by doing the following:
```
cd /usr/lib/python3/dist-packages/
sudo ln -s apt_pkg.cpython-{35m,37m}-x86_64-linux-gnu.so
```