### PR TITLE
Add badges for flagging activities

### DIFF
--- a/app/models/badges/definitions.rb
+++ b/app/models/badges/definitions.rb
@@ -45,6 +45,16 @@ module Badges
           display_name: 'Gene Specialist',
           description: 'Awarded for contributing multiple Evidence Items related to a specific gene'
         },
+        {
+          name: 'Flagger',
+          display_name: 'Flagger',
+          description: 'Awarded for flagging problematic entities in CIViC'
+        },
+        {
+          name: 'Flag Resolver',
+          display_name: 'Flag Resolver',
+          description: 'Awarded for resolving outstanding flags on CIViC entities'
+        },
         # badges for attending NKI 2016 events
         {
           name: 'NKI 2016 Hackathon',

--- a/app/models/badges/rules.rb
+++ b/app/models/badges/rules.rb
@@ -33,6 +33,55 @@ module Badges
         Event.where(action: 'commented', originating_user: user).count >= 500
       end
 
+      #flag rules
+      flag_creation_actions = [
+        'assertion_flags#create',
+        'evidence_item_flags#create',
+        'gene_flags#create',
+        'variant_flags#create',
+        'variant_group_flags#create',
+      ]
+      grant 'Flagger', tier: 'bronze', on: flag_creation_actions do |user, params|
+        @message = 'Awarded for flagging your first entity in CIViC'
+        Event.where(action: 'flagged', originating_user: user).count >= 1
+      end
+      grant 'Flagger', tier: 'silver', on: flag_creation_actions do |user, params|
+        @message = 'Awarded for flagging 5 entities in CIViC'
+        Event.where(action: 'flagged', originating_user: user).count >= 5
+      end
+      grant 'Flagger', tier: 'gold', on: flag_creation_actions do |user, params|
+        @message = 'Awarded for flagging 10 entities in CIViC'
+        Event.where(action: 'flagged', originating_user: user).count >= 10
+      end
+      grant 'Flagger', tier: 'platinum', on: flag_creation_actions do |user, params|
+        @message = 'Awarded for flagging 25 entities in CIViC'
+        Event.where(action: 'flagged', originating_user: user).count >= 25
+      end
+
+      flag_resolution_actions = [
+        'assertion_flags#update',
+        'evidence_item_flags#update',
+        'gene_flags#update',
+        'variant_flags#update',
+        'variant_group_flags#update',
+      ]
+      grant 'Flag Resolver', tier: 'bronze', on: flag_resolution_actions do |user, params|
+        @message = 'Awarded for resolving your first flag in CIViC'
+        Event.where(action: 'flag resolved', originating_user: user).count >= 1
+      end
+      grant 'Flag Resolver', tier: 'silver', on: flag_resolution_actions do |user, params|
+        @message = 'Awarded for resolving 5 flags'
+        Event.where(action: 'flag resolved', originating_user: user).count >= 5
+      end
+      grant 'Flag Resolver', tier: 'gold', on: flag_resolution_actions do |user, params|
+        @message = 'Awarded for resolving 10 flags'
+        Event.where(action: 'flag resolved', originating_user: user).count >= 10
+      end
+      grant 'Flag Resolver', tier: 'platinum', on: flag_resolution_actions do |user, params|
+        @message = 'Awarded for resolving 25 flags'
+        Event.where(action: 'flag resolved', originating_user: user).count >= 25
+      end
+
       #evidence items
       grant 'Submittor', tier: 'bronze', on: 'evidence_items#accept' do |user, params|
         submitter = EvidenceItem.find(params[:evidence_item_id]).submitter
@@ -214,6 +263,7 @@ module Badges
           .group('genes.id').count
           .values.any? { |x| x >= 50}
       end
+
 
       #misc
       grant 'Biographer', tier: 'bronze', on: 'users#update' do |user, params|


### PR DESCRIPTION
This adds badges for both creating and resolving flags. @malachig had suggested tiers of 1, 5, 10, and 25 as flagging is a relatively rare activity.

closes griffithlab/civic-client#1225