### PR TITLE
Make EvidenceItem and Assertion responses to changes consistent

### DIFF
--- a/app/models/assertion.rb
+++ b/app/models/assertion.rb
@@ -107,6 +107,20 @@ class Assertion < ActiveRecord::Base
     }
   end
 
+  def after_change_accept(change)
+    if self.status == 'rejected'
+      self.status = 'submitted'
+      self.save
+    end
+  end
+
+  def on_change_suggested
+    if self.status == 'rejected'
+      self.status = 'submitted'
+      self.save
+    end
+  end
+
   def additional_changes_info
     @@additional_variant_changes ||= {
       'evidence_items' => {

--- a/app/models/concerns/moderated.rb
+++ b/app/models/concerns/moderated.rb
@@ -33,6 +33,7 @@ module Moderated
       raise NoSuggestedChangesError
     else
       SuggestedChange.create(user: user, suggested_changes: c, moderated: self).tap do
+        on_change_suggested
         reload
       end
     end
@@ -115,6 +116,9 @@ module Moderated
   end
 
   def after_change_accept(change)
+  end
+
+  def on_change_suggested
   end
 
   private

--- a/app/models/evidence_item.rb
+++ b/app/models/evidence_item.rb
@@ -158,16 +158,6 @@ class EvidenceItem < ActiveRecord::Base
     }
   end
 
-  def suggest_change!(user, direct_changes, additional_changes)
-    ActiveRecord::Base.transaction do
-      if self.status == 'rejected'
-        self.status = 'submitted'
-        self.save
-      end
-      super
-    end
-  end
-
   def self.timepoint_query
     ->(x) {
             self.where("evidence_items.status != 'rejected'")
@@ -184,6 +174,13 @@ class EvidenceItem < ActiveRecord::Base
       last_commented_on: :last_comment_event
     }.tap do |events_hash|
       events_hash[self.status.to_sym] = :current_status_event
+    end
+  end
+
+  def on_change_suggested
+    if self.status == 'rejected'
+      self.status = 'submitted'
+      self.save
     end
   end
 

--- a/spec/fabricators/assertion_fabricator.rb
+++ b/spec/fabricators/assertion_fabricator.rb
@@ -1,0 +1,13 @@
+Fabricator(:assertion) do
+  evidence_items(count: 1) { |attrs, i| Fabricate(:evidence_item) }
+  gene
+  variant
+  disease
+  description { sequence(:ai_text) { |i| "Assertion Description ##{i}" } }
+  summary { sequence(:ai_summary) { |i| "Assertion Summary ##{i}" } }
+  status 'submitted'
+  evidence_direction { Assertion.evidence_directions.keys.sample }
+  evidence_type { Assertion.evidence_types.keys.sample }
+  clinical_significance { Assertion.clinical_significances.keys.sample }
+end
+

--- a/spec/models/change_resets_submission_spec.rb
+++ b/spec/models/change_resets_submission_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+
+describe 'Entities that are un-rejected on change accept' do
+  before(:each) do
+    @entities = [Fabricate(:evidence_item), Fabricate(:assertion)]
+    @user = Fabricate(:user)
+  end
+
+  it "should change the entity back to 'submitted' if it was rejected and a change was accepted" do
+    @entities.each do |entity|
+      entity.description = 'foo'
+      entity.suggest_change!(@user, {}, {})
+      entity.status = 'rejected'
+      entity.save
+      change = entity.open_changes.first
+      change.apply(@user, false)
+      entity.reload
+      expect(entity.status).to eq('submitted')
+    end
+  end
+
+  it "should change the entity back to 'submitted' if it was rejected and a new change is proposed" do
+    @entities.each do |entity|
+      entity.status = 'rejected'
+      entity.save
+      entity.description = 'foo'
+      entity.suggest_change!(@user, {}, {})
+      entity.reload
+      expect(entity.status).to eq('submitted')
+    end
+  end
+
+  it "should not change the status if the item was already accepted" do
+    @entities.each do |entity|
+      entity.status = 'accepted'
+      entity.save
+      entity.description = 'foo'
+      entity.suggest_change!(@user, {}, {})
+      change = entity.open_changes.first
+      change.apply(@user, false)
+      entity.reload
+      expect(entity.status).to eq('accepted')
+    end
+  end
+end
+


### PR DESCRIPTION
Now, if an evidence item or assertion is rejected and someone proposes a
change to it, it will return to 'submitted' status. Likewise accepting a
change to a rejected item will return it to 'submitted' status.

closes griffithlab/civic-client#1256