### PR TITLE
Catch errors in CIViCpy jobs before rescheduling

### DIFF
--- a/app/jobs/create_civic_vcfs.rb
+++ b/app/jobs/create_civic_vcfs.rb
@@ -6,7 +6,7 @@ class CreateCivicVcfs < ActiveJob::Base
   end
 
   def perform(recurring = true)
-    @recurring if recurring
+    @recurring = recurring
     execute
   end
 

--- a/app/jobs/create_civic_vcfs.rb
+++ b/app/jobs/create_civic_vcfs.rb
@@ -1,7 +1,13 @@
 class CreateCivicVcfs < ActiveJob::Base
-  def perform
+  attr_reader :recurring
+
+  after_perform do |job|
+    job.reschedule if job.recurring
+  end
+
+  def perform(recurring = true)
+    @recurring if recurring
     execute
-    reschedule
   end
 
   def execute

--- a/app/jobs/create_civicpy_cache_pkl.rb
+++ b/app/jobs/create_civicpy_cache_pkl.rb
@@ -6,7 +6,7 @@ class CreateCivicpyCachePkl < ActiveJob::Base
   end
 
   def perform(recurring = true)
-    @recurring if recurring
+    @recurring = recurring
     execute
   end
 

--- a/app/jobs/create_civicpy_cache_pkl.rb
+++ b/app/jobs/create_civicpy_cache_pkl.rb
@@ -1,7 +1,13 @@
 class CreateCivicpyCachePkl < ActiveJob::Base
-  def perform
+  attr_reader :recurring
+
+  after_perform do |job|
+    job.reschedule if job.recurring
+  end
+
+  def perform(recurring = true)
+    @recurring if recurring
     execute
-    reschedule
   end
 
   def execute


### PR DESCRIPTION
The CIViCpy-related jobs are rescheduling and not marked as failed but don't appear to actually create the files. Hopefully, this will catch this and allows us to debug the reason for them not working right.