### PR TITLE
Reload the advanced search query

### DIFF
--- a/app/models/advanced_searches/base.rb
+++ b/app/models/advanced_searches/base.rb
@@ -12,8 +12,9 @@ module AdvancedSearches
         query_segments.push(*additional_query_segments)
         param_values.push(*additional_param_values)
       end
-      query = model_class.advanced_search_scope
-        .where(query_segments.join(boolean_operator), *param_values)
+      ids = model_class.advanced_search_scope
+        .where(query_segments.join(boolean_operator), *param_values).pluck(:id)
+      query = model_class.advanced_search_scope.where("#{model_class.table_name}.id" => ids)
       if params['count'].present?
         query.order("#{model_class.table_name}.id asc")
         .page(params['page'])


### PR DESCRIPTION
This ensures that for any join tables that are being queried, the
association is fully loaded. E.g., if searching evidence by drug name, this will
ensure that all associated drugs are returned, not just the ones that
match the drug name query.

Closes https://github.com/griffithlab/civic-client/issues/1200