### PR TITLE
Add "Hazardous or Poisonous Substance" to NCIt semantic types to import

### DIFF
--- a/lib/importer/nci_thesaurus_mirror.rb
+++ b/lib/importer/nci_thesaurus_mirror.rb
@@ -19,13 +19,17 @@ module Importer
       semantic_types = semantic_types(entry)
       obsolete_concepts = obsolete_concepts(entry)
       (entry['id'].present? && entry['name'].present? && entry.respond_to?(:name) && entry.name == 'Term' &&
-        (semantic_types & ['Pharmacologic Substance', 'Pharmacological Substance', 'Clinical Drug', 'Therapeutic or Preventive Procedure']).length > 0 &&
+        (semantic_types & valid_semantic_types).length > 0 &&
         (obsolete_concepts & ['Obsolete_Concept']).length == 0)
     end
 
     def semantic_types(entry)
       matcher = /^NCIT:P106 "(?<semantic_type>.+)"/
       entry['property_value'].map { |s| s.match(matcher) }.compact.map { |s| s[:semantic_type] }
+    end
+
+    def valid_semantic_types
+      ['Pharmacologic Substance', 'Pharmacological Substance', 'Clinical Drug', 'Therapeutic or Preventive Procedure', 'Hazardous or Poisonous Substance']
     end
 
     def obsolete_concepts(entry)


### PR DESCRIPTION
Closes https://github.com/griffithlab/civic-client/issues/1264. I've confirmed that this change imports the missing term.