### PR TITLE
Ensure that direct links route through cividb.org and not the old civic.genome.wustl.edu

### DIFF
--- a/app/models/frontend_router.rb
+++ b/app/models/frontend_router.rb
@@ -46,6 +46,6 @@ class FrontendRouter
   end
 
   def domain
-    'https://civic.genome.wustl.edu/'
+    'https://civicdb.org/'
   end
 end


### PR DESCRIPTION
Closes https://github.com/griffithlab/civic-client/issues/1272