### PR TITLE
Add gene_alias search option to advanced search

### DIFF
--- a/app/models/advanced_searches/assertion.rb
+++ b/app/models/advanced_searches/assertion.rb
@@ -24,6 +24,7 @@ module AdvancedSearches
         'drug_name' => default_handler.curry['drugs.name'],
         'drug_id' => default_handler.curry['drugs.pubchem_id'],
         'gene_name' => default_handler.curry['genes.name'],
+        'gene_alias' => default_handler.curry['gene_aliases.name'],
         'variant_name' => default_handler.curry['variants.name'],
         'variant_alias' => default_handler.curry['variant_aliases.name'],
         'status' => default_handler.curry['assertions.status'],

--- a/app/models/advanced_searches/base.rb
+++ b/app/models/advanced_searches/base.rb
@@ -86,7 +86,7 @@ module AdvancedSearches
       when 'does_not_contain'
         '%%%s%%'
       when 'begins_with'
-        '%s%'
+        '%s%%'
       else
         '%s'
       end

--- a/app/models/advanced_searches/evidence_item.rb
+++ b/app/models/advanced_searches/evidence_item.rb
@@ -24,6 +24,7 @@ module AdvancedSearches
         'drug_name' => default_handler.curry['drugs.name'],
         'drug_id' => default_handler.curry['drugs.pubchem_id'],
         'gene_name' => default_handler.curry['genes.name'],
+        'gene_alias' => default_handler.curry['gene_aliases.name'],
         'pubmed_id' => method(:handle_pubmed_id),
         'asco_id' => method(:handle_asco_id),
         'asco_abstract_id' => default_handler.curry['sources.asco_abstract_id'],

--- a/app/models/assertion.rb
+++ b/app/models/assertion.rb
@@ -69,7 +69,7 @@ class Assertion < ActiveRecord::Base
   end
 
   def self.advanced_search_scope
-    eager_load(:gene, :disease, :drugs, :phenotypes, :acmg_codes, :open_changes, submitter: [:organization], variant: [:variant_aliases])
+    eager_load(:disease, :drugs, :phenotypes, :acmg_codes, :open_changes, submitter: [:organization], variant: [:variant_aliases], gene: [:gene_aliases])
   end
 
   def name

--- a/app/models/evidence_item.rb
+++ b/app/models/evidence_item.rb
@@ -59,7 +59,7 @@ class EvidenceItem < ActiveRecord::Base
   end
 
   def self.advanced_search_scope
-    eager_load(:disease,:drugs, :phenotypes, :open_changes, source: [:clinical_trials], submitter: [:organization], variant: [:gene, :variant_aliases])
+    eager_load(:disease,:drugs, :phenotypes, :open_changes, source: [:clinical_trials], submitter: [:organization], variant: [:variant_aliases, gene: [:gene_aliases]])
   end
 
   def self.variant_group_scope


### PR DESCRIPTION
This adds gene_alias as a search option to the assertion and evidence item advanced searches. It also fixes a bug with the begins_with term parser.

Prerequisite for https://github.com/griffithlab/civic-client/issues/1140