### PR TITLE
If no DOID is present, provide no link.

### DIFF
--- a/app/presenters/disease_presenter.rb
+++ b/app/presenters/disease_presenter.rb
@@ -19,7 +19,7 @@ class DiseasePresenter
     if disease.doid.present?
       "http://www.disease-ontology.org/?id=DOID:#{disease.doid}"
     else
-      "http://www.disease-ontology.org/"
+      nil
     end
   end
 end


### PR DESCRIPTION
This is as opposed to the previous link that was just to the homepage.

Supports griffithlab/civic-client#1271