### PR TITLE
Make nccn_guideline on assertions a foreign key table instead of enum

### DIFF
--- a/app/admin/assertion.rb
+++ b/app/admin/assertion.rb
@@ -1,10 +1,10 @@
 ActiveAdmin.register Assertion do
-  permit_params :summary, :description, :gene_id, :variant_id, :disease_id, :drug_interaction_type, :fda_regulatory_approval, :fda_companion_test, :nccn_guideline, :nccn_guideline_version, :evidence_type, :evidence_direction, :amp_level, :clinical_significance, evidence_item_ids: [], acmg_code_ids: [], drug_ids: [], phenotype_ids: []
+  permit_params :summary, :description, :gene_id, :variant_id, :disease_id, :drug_interaction_type, :fda_regulatory_approval, :fda_companion_test, :nccn_guideline_id, :nccn_guideline_version, :evidence_type, :evidence_direction, :amp_level, :clinical_significance, evidence_item_ids: [], acmg_code_ids: [], drug_ids: [], phenotype_ids: []
 
   filter :gene, as: :select, collection: ->(){ Gene.order(:name).all }
   filter :name
   filter :acmg_codes
-  filter :nccn_guideline, as: :select, collection: ->(){ Assertion.nccn_guidelines }
+  filter :nccn_guideline, as: :select, collection: ->(){ NccnGuideline.order(:name).all }
   filter :nccn_guideline_version
   filter :amp_level, as: :select, collection: ->(){ Assertion.amp_levels }
   filter :clinical_significance, as: :select, collection: ->(){ Assertion.clinical_significances }
@@ -29,7 +29,7 @@ ActiveAdmin.register Assertion do
       f.input :drug_interaction_type, as: :select, collection: Assertion.drug_interaction_types.keys, include_blank: true
       f.input :fda_regulatory_approval
       f.input :fda_companion_test
-      f.input :nccn_guideline, as: :select, collection: Assertion.nccn_guidelines.keys, include_blank: true
+      f.input :nccn_guideline, as: :select, collection: NccnGuideline.order(:name), include_blank: true
       f.input :nccn_guideline_version
       f.input :evidence_type, as: :select, collection: Assertion.evidence_types.keys, include_blank: false
       f.input :evidence_direction, as: :select, collection: Assertion.evidence_directions.keys, include_blank: false

--- a/app/admin/nccn_guideline.rb
+++ b/app/admin/nccn_guideline.rb
@@ -1,0 +1,25 @@
+ActiveAdmin.register NccnGuideline do
+  permit_params :name
+
+  filter :name
+
+  form do |f|
+    f.semantic_errors(*f.object.errors.keys)
+    f.inputs do
+      f.input :name
+    end
+    f.actions
+  end
+
+  index do
+    selectable_column
+    column :name
+    actions
+  end
+
+  show do |f|
+    attributes_table do
+      row :name
+    end
+  end
+end

--- a/app/controllers/assertion_moderations_controller.rb
+++ b/app/controllers/assertion_moderations_controller.rb
@@ -14,8 +14,11 @@ class AssertionModerationsController < ModerationsController
     if params[:variant].present?
       params[:variant] = params[:variant][:name]
     end
+    if params[:nccn_guideline].present?
+      params[:nccn_guideline] = params[:nccn_guideline][:name]
+    end
 
-    params.permit(:summary, :description, :gene, :variant, :disease, :nccn_guideline, :nccn_guideline_version, :evidence_type, :evidence_direction, :amp_level, :clinical_significance, :drug_interaction_type, :fda_regulatory_approval, :fda_companion_test, :variant_origin)
+    params.permit(:summary, :description, :gene, :variant, :disease, :nccn_guideline_version, :evidence_type, :evidence_direction, :amp_level, :clinical_significance, :drug_interaction_type, :fda_regulatory_approval, :fda_companion_test, :variant_origin)
   end
 
   def additional_moderation_params

--- a/app/controllers/assertion_moderations_controller.rb
+++ b/app/controllers/assertion_moderations_controller.rb
@@ -18,7 +18,7 @@ class AssertionModerationsController < ModerationsController
       params[:nccn_guideline] = params[:nccn_guideline][:name]
     end
 
-    params.permit(:summary, :description, :gene, :variant, :disease, :nccn_guideline_version, :evidence_type, :evidence_direction, :amp_level, :clinical_significance, :drug_interaction_type, :fda_regulatory_approval, :fda_companion_test, :variant_origin)
+    params.permit(:summary, :description, :gene, :variant, :disease, :nccn_guideline, :nccn_guideline_version, :evidence_type, :evidence_direction, :amp_level, :clinical_significance, :drug_interaction_type, :fda_regulatory_approval, :fda_companion_test, :variant_origin)
   end
 
   def additional_moderation_params

--- a/app/controllers/assertions_controller.rb
+++ b/app/controllers/assertions_controller.rb
@@ -118,7 +118,7 @@ class AssertionsController < ApplicationController
       evidence_items: [],
       acmg_codes: [],
       phenotypes: [],
-      nccn_guideline: [:name],
+      nccn_guideline: [:id, :name],
     )
   end
 

--- a/app/controllers/assertions_controller.rb
+++ b/app/controllers/assertions_controller.rb
@@ -102,7 +102,6 @@ class AssertionsController < ApplicationController
       :evidence_type,
       :clinical_significance,
       :amp_level,
-      :nccn_guideline,
       :nccn_guideline_version,
       :fda_regulatory_approval,
       :fda_companion_test,
@@ -119,6 +118,7 @@ class AssertionsController < ApplicationController
       evidence_items: [],
       acmg_codes: [],
       phenotypes: [],
+      nccn_guideline: [:name],
     )
   end
 

--- a/app/controllers/nccn_guidelines_controller.rb
+++ b/app/controllers/nccn_guidelines_controller.rb
@@ -1,0 +1,24 @@
+class NccnGuidelinesController < ApplicationController
+  actions_without_auth :index
+
+  def index
+    guidelines = NccnGuideline.page(params[:page])
+      .per(params[:count])
+    guidelines = filter_by_query(guidelines)
+    render json: guidelines.map { |g| { id: g.id, name: g.name } }
+  end
+
+  private
+  def filter_by_query(query)
+    if (q = params[:query]).present?
+      if params[:exact_match].present? and ActiveRecord::Type::Boolean.new.type_cast_from_user(params[:exact_match])
+        query.where('nccn_guidelines.name = :query', query: q)
+      else
+        query.where('nccn_guidelines.name ILIKE :query', query: "%#{q}%")
+          .order("LENGTH(nccn_guidelines.name) ASC")
+      end
+    else
+      query
+    end
+  end
+end

--- a/app/models/actions/propose_assertion.rb
+++ b/app/models/actions/propose_assertion.rb
@@ -20,6 +20,7 @@ module Actions
         item.evidence_items = get_evidence_items(relational_attributes)
         item.acmg_codes = get_acmg_codes(relational_attributes)
         item.phenotypes = get_phenotypes(relational_attributes)
+        item.nccn_guideline = get_nccn_guideline(relational_attributes)
         item.save
       end
       Event.create(
@@ -62,6 +63,10 @@ module Actions
 
     def get_phenotypes(params)
       Array(params[:phenotypes]).map{ |hpo_class| Phenotype.find_by(hpo_class: hpo_class) }.sort.uniq
+    end
+
+    def get_nccn_guideline(params)
+      NccnGuideline.find(params[:nccn_guideline][:id])
     end
   end
 end

--- a/app/models/assertion.rb
+++ b/app/models/assertion.rb
@@ -12,6 +12,7 @@ class Assertion < ActiveRecord::Base
   belongs_to :gene
   belongs_to :variant
   belongs_to :disease
+  belongs_to :nccn_guideline
   has_and_belongs_to_many :acmg_codes
   has_and_belongs_to_many :evidence_items
   has_and_belongs_to_many :drugs
@@ -42,7 +43,7 @@ class Assertion < ActiveRecord::Base
   associate_by_attribute :variant, :name
 
   enum evidence_type: Constants::EVIDENCE_TYPES
-  enum nccn_guideline: Constants::NCCN_GUIDELINES
+  enum nccn_guideline_old: Constants::NCCN_GUIDELINES
   enum amp_level: Constants::AMP_LEVELS
   enum clinical_significance: Constants::CLINICAL_SIGNIFICANCES
   enum drug_interaction_type: Constants::DRUG_INTERACTION_TYPES

--- a/app/models/assertion.rb
+++ b/app/models/assertion.rb
@@ -41,6 +41,7 @@ class Assertion < ActiveRecord::Base
   associate_by_attribute :disease, :name
   associate_by_attribute :gene, :name
   associate_by_attribute :variant, :name
+  associate_by_attribute :nccn_guideline, :name
 
   enum evidence_type: Constants::EVIDENCE_TYPES
   enum nccn_guideline_old: Constants::NCCN_GUIDELINES

--- a/app/models/nccn_guideline.rb
+++ b/app/models/nccn_guideline.rb
@@ -1,3 +1,7 @@
 class NccnGuideline < ActiveRecord::Base
   has_many :assertions
+
+  def display_name
+    name
+  end
 end

--- a/app/models/nccn_guideline.rb
+++ b/app/models/nccn_guideline.rb
@@ -1,0 +1,3 @@
+class NccnGuideline < ActiveRecord::Base
+  has_many :assertions
+end

--- a/app/presenters/assertion_detail_presenter.rb
+++ b/app/presenters/assertion_detail_presenter.rb
@@ -2,7 +2,7 @@ class AssertionDetailPresenter < AssertionIndexPresenter
   def as_json(opts = {})
     super.merge(
       {
-        nccn_guideline: assertion.nccn_guideline,
+        nccn_guideline: assertion.nccn_guideline.name,
         nccn_guideline_version: assertion.nccn_guideline_version,
         amp_level: assertion.amp_level,
         evidence_items: assertion.evidence_items.map { |ei| EvidenceItemWithStateParamsPresenter.new(ei) },

--- a/app/presenters/assertion_detail_presenter.rb
+++ b/app/presenters/assertion_detail_presenter.rb
@@ -2,7 +2,7 @@ class AssertionDetailPresenter < AssertionIndexPresenter
   def as_json(opts = {})
     super.merge(
       {
-        nccn_guideline: assertion.nccn_guideline.name,
+        nccn_guideline: (assertion.nccn_guideline.nil? ? nil : assertion.nccn_guideline.name),
         nccn_guideline_version: assertion.nccn_guideline_version,
         amp_level: assertion.amp_level,
         evidence_items: assertion.evidence_items.map { |ei| EvidenceItemWithStateParamsPresenter.new(ei) },

--- a/app/presenters/assertion_tsv_presenter.rb
+++ b/app/presenters/assertion_tsv_presenter.rb
@@ -51,7 +51,7 @@ class AssertionTsvPresenter
       a.clinical_significance,
       a.acmg_codes.map(&:code).join(','),
       a.amp_level,
-      a.nccn_guideline.name,
+      (a.nccn_guideline.nil? ? nil : a.nccn_guideline.name),
       a.nccn_guideline_version,
       a.fda_regulatory_approval,
       a.fda_companion_test,

--- a/app/presenters/assertion_tsv_presenter.rb
+++ b/app/presenters/assertion_tsv_presenter.rb
@@ -51,7 +51,7 @@ class AssertionTsvPresenter
       a.clinical_significance,
       a.acmg_codes.map(&:code).join(','),
       a.amp_level,
-      a.nccn_guideline,
+      a.nccn_guideline.name,
       a.nccn_guideline_version,
       a.fda_regulatory_approval,
       a.fda_companion_test,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -178,6 +178,7 @@ Rails.application.routes.draw do
     get '/acmg_codes' => 'acmg_codes#index'
     get '/regulatory_agencies' => 'regulatory_agencies#index'
     get '/phenotypes' => 'phenotypes#index'
+    get '/nccn_guidelines' => 'nccn_guidelines#index'
 
     get '/variant_types' => 'variant_types#index'
     get 'variant_types/relationships' => 'variant_types#relationships'

--- a/db/migrate/20200107192356_add_nccn_guidlines_table.rb
+++ b/db/migrate/20200107192356_add_nccn_guidlines_table.rb
@@ -1,0 +1,68 @@
+class AddNccnGuidlinesTable < ActiveRecord::Migration[5.2]
+  def change
+    rename_column :assertions, :nccn_guideline, :nccn_guideline_old
+    create_table :nccn_guidelines do |t|
+      t.text :name, null: false
+      t.timestamp
+    end
+    add_reference :assertions, :nccn_guideline, index: true, foreign_key: true
+
+    NccnGuideline.reset_column_information
+    NccnGuideline.create(:name => 'Acute Lymphoblastic Leukemia')
+    NccnGuideline.create(:name => 'Acute Myeloid Leukemia')
+    NccnGuideline.create(:name => 'Anal Carcinoma')
+    NccnGuideline.create(:name => 'Bladder Cancer')
+    NccnGuideline.create(:name => 'Bone Cancer')
+    NccnGuideline.create(:name => 'Breast Cancer')
+    NccnGuideline.create(:name => 'Central Nervous System Cancers')
+    NccnGuideline.create(:name => 'Cervical Cancer')
+    NccnGuideline.create(:name => 'Chronic Lymphocytic Leukemia/Small Lymphocytic Lymphoma')
+    NccnGuideline.create(:name => 'Chronic Myeloid Leukemia')
+    NccnGuideline.create(:name => 'Colon/Rectal Cancer')
+    NccnGuideline.create(:name => 'Colon Cancer')
+    NccnGuideline.create(:name => 'Rectal Cancer')
+    NccnGuideline.create(:name => 'Esophageal and Esophagogastric Junction Cancers')
+    NccnGuideline.create(:name => 'Gastric Cancer')
+    NccnGuideline.create(:name => 'Hairy Cell Leukemia')
+    NccnGuideline.create(:name => 'Head and Neck Cancers')
+    NccnGuideline.create(:name => 'Hepatobiliary Cancers')
+    NccnGuideline.create(:name => 'Hodgkin Lymphoma')
+    NccnGuideline.create(:name => 'Kidney Cancer')
+    NccnGuideline.create(:name => 'Malignant Pleural Mesothelioma')
+    NccnGuideline.create(:name => 'Melanoma')
+    NccnGuideline.create(:name => 'Multiple Myeloma/Other Plasma Cell Neoplasms')
+    NccnGuideline.create(:name => 'Multiple Myeloma')
+    NccnGuideline.create(:name => 'Systemic Light Chain Amyloidosis')
+    NccnGuideline.create(:name => "Waldenström's Macroglobulinemia / Lymphoplasmacytic Lymphoma")
+    NccnGuideline.create(:name => 'Myelodysplastic Syndromes')
+    NccnGuideline.create(:name => 'Myeloproliferative Neoplasms')
+    NccnGuideline.create(:name => 'Neuroendocrine Tumors')
+    NccnGuideline.create(:name => "Non-Hodgkin's Lymphomas")
+    NccnGuideline.create(:name => 'B-Cell Lymphomas')
+    NccnGuideline.create(:name => 'Primary Cutaneous B-Cell Lymphomas')
+    NccnGuideline.create(:name => 'T-Cell Lymphomas')
+    NccnGuideline.create(:name => 'Non-Melanoma Skin Cancers')
+    NccnGuideline.create(:name => 'Basal Cell Skin Cancer')
+    NccnGuideline.create(:name => 'Dermatofibrosarcoma Protuberans')
+    NccnGuideline.create(:name => 'Merkel Cell Carcinoma')
+    NccnGuideline.create(:name => 'Squamous Cell Skin Cancer')
+    NccnGuideline.create(:name => 'Non-Small Cell Lung Cancer')
+    NccnGuideline.create(:name => 'Occult Primary')
+    NccnGuideline.create(:name => 'Ovarian Cancer')
+    NccnGuideline.create(:name => 'Pancreatic Adenocarcinoma')
+    NccnGuideline.create(:name => 'Penile Cancer')
+    NccnGuideline.create(:name => 'Prostate Cancer')
+    NccnGuideline.create(:name => 'Small Cell Lung Cancer')
+    NccnGuideline.create(:name => 'Soft Tissue Sarcoma')
+    NccnGuideline.create(:name => 'Testicular Cancer')
+    NccnGuideline.create(:name => 'Thymomas and Thymic Carcinomas')
+    NccnGuideline.create(:name => 'Thyroid Carcinoma')
+    NccnGuideline.create(:name => 'Uterine Neoplasms')
+    NccnGuideline.create(:name => 'Vulvar Cancer')
+
+    Assertion.where.not(nccn_guideline_old: nil).each do |a|
+      a.nccn_guideline = NccnGuideline.find_by(name: a.nccn_guideline_old)
+      a.save
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_02_193805) do
+ActiveRecord::Schema.define(version: 2020_01_07_192356) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -43,7 +43,7 @@ ActiveRecord::Schema.define(version: 2020_01_02_193805) do
     t.datetime "updated_at"
     t.boolean "deleted", default: false
     t.text "status", default: "submitted", null: false
-    t.integer "nccn_guideline"
+    t.integer "nccn_guideline_old"
     t.text "nccn_guideline_version"
     t.integer "amp_level"
     t.integer "clinical_significance"
@@ -57,10 +57,12 @@ ActiveRecord::Schema.define(version: 2020_01_02_193805) do
     t.integer "evidence_direction"
     t.text "summary"
     t.integer "variant_origin"
+    t.bigint "nccn_guideline_id"
     t.index ["description"], name: "index_assertions_on_description"
     t.index ["disease_id"], name: "index_assertions_on_disease_id"
     t.index ["drug_interaction_type"], name: "index_assertions_on_drug_interaction_type"
     t.index ["gene_id"], name: "index_assertions_on_gene_id"
+    t.index ["nccn_guideline_id"], name: "index_assertions_on_nccn_guideline_id"
     t.index ["variant_id"], name: "index_assertions_on_variant_id"
     t.index ["variant_origin"], name: "index_assertions_on_variant_origin"
   end
@@ -435,6 +437,10 @@ ActiveRecord::Schema.define(version: 2020_01_02_193805) do
     t.index ["variant_id", "hgvs_expression_id"], name: "idx_variant_id_hgvs_id"
   end
 
+  create_table "nccn_guidelines", force: :cascade do |t|
+    t.text "name", null: false
+  end
+
   create_table "notifications", id: :serial, force: :cascade do |t|
     t.integer "notified_user_id"
     t.integer "originating_user_id"
@@ -711,6 +717,7 @@ ActiveRecord::Schema.define(version: 2020_01_02_193805) do
 
   add_foreign_key "acmg_codes_assertions", "acmg_codes"
   add_foreign_key "acmg_codes_assertions", "assertions"
+  add_foreign_key "assertions", "nccn_guidelines"
   add_foreign_key "assertions_drugs", "assertions"
   add_foreign_key "assertions_drugs", "drugs"
   add_foreign_key "assertions_evidence_items", "assertions"

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -110,7 +110,7 @@ CREATE TABLE public.assertions (
     updated_at timestamp without time zone,
     deleted boolean DEFAULT false,
     status text DEFAULT 'submitted'::text NOT NULL,
-    nccn_guideline integer,
+    nccn_guideline_old integer,
     nccn_guideline_version text,
     amp_level integer,
     clinical_significance integer,
@@ -123,7 +123,8 @@ CREATE TABLE public.assertions (
     drug_interaction_type integer,
     evidence_direction integer,
     summary text,
-    variant_origin integer
+    variant_origin integer,
+    nccn_guideline_id bigint
 );
 
 
@@ -1236,6 +1237,35 @@ CREATE TABLE public.hgvs_expressions_variants (
 
 
 --
+-- Name: nccn_guidelines; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.nccn_guidelines (
+    id bigint NOT NULL,
+    name text NOT NULL
+);
+
+
+--
+-- Name: nccn_guidelines_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.nccn_guidelines_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: nccn_guidelines_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.nccn_guidelines_id_seq OWNED BY public.nccn_guidelines.id;
+
+
+--
 -- Name: notifications; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -2093,6 +2123,13 @@ ALTER TABLE ONLY public.hgvs_expressions ALTER COLUMN id SET DEFAULT nextval('pu
 
 
 --
+-- Name: nccn_guidelines id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.nccn_guidelines ALTER COLUMN id SET DEFAULT nextval('public.nccn_guidelines_id_seq'::regclass);
+
+
+--
 -- Name: notifications id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -2445,6 +2482,14 @@ ALTER TABLE ONLY public.hgvs_expressions
 
 
 --
+-- Name: nccn_guidelines nccn_guidelines_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.nccn_guidelines
+    ADD CONSTRAINT nccn_guidelines_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: notifications notifications_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -2746,6 +2791,13 @@ CREATE INDEX index_assertions_on_drug_interaction_type ON public.assertions USIN
 --
 
 CREATE INDEX index_assertions_on_gene_id ON public.assertions USING btree (gene_id);
+
+
+--
+-- Name: index_assertions_on_nccn_guideline_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_assertions_on_nccn_guideline_id ON public.assertions USING btree (nccn_guideline_id);
 
 
 --
@@ -3781,6 +3833,14 @@ ALTER TABLE ONLY public.authors_sources
 
 
 --
+-- Name: assertions fk_rails_cb9e41518d; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.assertions
+    ADD CONSTRAINT fk_rails_cb9e41518d FOREIGN KEY (nccn_guideline_id) REFERENCES public.nccn_guidelines(id);
+
+
+--
 -- Name: evidence_items fk_rails_d22bcc06f7; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -3983,6 +4043,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20190822211502'),
 ('201909062411'),
 ('20191014213854'),
-('20200102193805');
+('20200102193805'),
+('20200107192356');
 
 


### PR DESCRIPTION
Prerequisite for https://github.com/griffithlab/civic-client/issues/1255.

This will require some frontend changes to get suggested changes to work. There will also need to be a second database migration to remove `nccn_guideline_old`. We will also probably want to add an endpoint that returns all available NCCN guidelines so that we can stop hardcoding them on the client side.