### PR TITLE
Fix bug with new browse table reload logic

### DIFF
--- a/app/datatables/datatable_base.rb
+++ b/app/datatables/datatable_base.rb
@@ -53,7 +53,7 @@ class DatatableBase
       if or_filters.length > 0
         filtered_objects = objects.where(or_filters.join(" OR "), *or_values)
       end
-      ids = filtered_objects.pluck(:id)
+      ids = filtered_objects.map{|o| o.id}
       objects.where('id' => ids)
     else
       objects


### PR DESCRIPTION
`pluck` doesn't work for queries that have SORT or GROUP BY statements since it replaces the SELECT part of the SQL query.
Replacing with map works since that gets executed after the initial SQL query runs.