### PR TITLE
Switch to using `Open3.capture3` instead of `system` calls

### DIFF
--- a/app/jobs/create_civic_vcfs.rb
+++ b/app/jobs/create_civic_vcfs.rb
@@ -1,11 +1,17 @@
+require 'open3'
+
 class CreateCivicVcfs < ApplicationJob
   def perform
     statuses.each do |description, status_list|
-      cmd = "civicpy create-vcf --vcf-file-path #{vcf_path(description)}"
+      cmd = ["civicpy", "create-vcf", "--vcf-file-path", vcf_path(description)]
       status_list.each do |status|
-        cmd += " --include-status #{status}"
+        cmd.concat(["--include-status", status])
       end
-      system(cmd)
+      binding.pry
+      stdout, stderr, process_status = Open3.capture3(*cmd)
+      if not process_status.success?
+        raise stderr
+      end
     end
   end
 

--- a/app/jobs/create_civicpy_cache_pkl.rb
+++ b/app/jobs/create_civicpy_cache_pkl.rb
@@ -1,7 +1,12 @@
+require 'open3'
+
 class CreateCivicpyCachePkl < ApplicationJob
 
   def perform
-    system("civicpy update --hard --cache-save-path #{civicpy_cache_file_location}")
+    stdout, stderr, status = Open3.capture3("civicpy", "update", "--hard", "--cache-save-path", civicpy_cache_file_location)
+    if not status.success?
+      raise stderr
+    end
   end
 
   private

--- a/lib/capistrano/tasks/dependencies.rake
+++ b/lib/capistrano/tasks/dependencies.rake
@@ -8,7 +8,7 @@ namespace :dependencies do
       execute "sudo apt-get update"
       execute "sudo apt-get -y install python3.7 python3-pip"
       execute :pip3, "install ndexutil -r #{current_path}/misc_scripts/ndex_requirements.txt --no-cache-dir --no-deps"
-      execute :pip3, "install civicpy==1.0.0rc2"
+      execute :pip3, "install civicpy==1.0.0rc5"
     end
   end
 end


### PR DESCRIPTION
Caveat: We also need to upgrade to the latest civicpy version. The dependencies rake task doesn't run automatically as part of the deploy process so we will need to do that manually. However, civicpy 1.0.0rc5 doesn't exist yet but it's the upcoming version that will include the required hotfix in https://github.com/griffithlab/civicpy/pull/75. 