### PR TITLE
Deserialize JSON to a HashWithIndifferentAccess

### DIFF
--- a/app/jobs/award_badges.rb
+++ b/app/jobs/award_badges.rb
@@ -1,6 +1,7 @@
 class AwardBadges < ApplicationJob
   def perform(user, controller, action, params_json)
-    evaluator = Badges::Evaluator.new(user, controller, action, JSON.parse(params_json))
+    params =  ActiveSupport::HashWithIndifferentAccess.new(JSON.parse(params_json))
+    evaluator = Badges::Evaluator.new(user, controller, action, params)
     evaluator.run
   end
 end


### PR DESCRIPTION
With the recent addition of serializing the params to JSON and back out we lost the default rails hash behavior of not distinguishing between symbols and strings for keys. That meant symbol based lookups in badge awards were failing. This deserializes the json and then turns it into the standard rails hash structure.