### PR TITLE
Restructure advanced search where in clause

### DIFF
--- a/app/models/advanced_searches/base.rb
+++ b/app/models/advanced_searches/base.rb
@@ -14,7 +14,7 @@ module AdvancedSearches
       end
       ids = model_class.advanced_search_scope
         .where(query_segments.join(boolean_operator), *param_values).pluck(:id)
-      query = model_class.advanced_search_scope.where("#{model_class.table_name}.id" => ids)
+      query = model_class.advanced_search_scope.where("#{model_class.table_name}.id IN (:ids)", ids: ids)
       if params['count'].present?
         query.order("#{model_class.table_name}.id asc")
         .page(params['page'])


### PR DESCRIPTION
For some reason, the previous implementation would not get resolved to
a SQL WHERE IN clause (but only for suggested changes). The new syntax
is more explicit and seems to work across the board.

Closes https://github.com/griffithlab/civic-client/issues/1314