### PR TITLE
Add sleep in pubmed scraping

### DIFF
--- a/app/jobs/fix_pubmed_entries_missing_authors.rb
+++ b/app/jobs/fix_pubmed_entries_missing_authors.rb
@@ -14,6 +14,7 @@ class FixPubmedEntriesMissingAuthors < ApplicationJob
   def get_authors_from_pubmed(sources)
     sources.each do |source|
       Scrapers::PubMed.populate_source_fields(source)
+      sleep 1
     end
   end
 end


### PR DESCRIPTION
This keeps getting throttled for hitting their rate limit. Since it
happens in the background anyways, we can just naively sleep between
requests