### PR TITLE
Handle coordinates passed in with commas

### DIFF
--- a/app/models/concerns/with_string_to_int_columns.rb
+++ b/app/models/concerns/with_string_to_int_columns.rb
@@ -1,0 +1,17 @@
+module WithStringToIntColumns
+  extend ActiveSupport::Concern
+
+  class_methods do
+    def string_to_int_columns(*cols)
+      cols.each do |col|
+        define_method "#{col}=" do |val|
+          if val.is_a?(String)
+            super(val.delete(','))
+          else
+            super(val)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/models/variant.rb
+++ b/app/models/variant.rb
@@ -7,6 +7,7 @@ class Variant < ActiveRecord::Base
   include WithDomainExpertTags
   include Flaggable
   include Commentable
+  include WithStringToIntColumns
 
   belongs_to :gene
   belongs_to :secondary_gene, class_name: 'Gene'
@@ -24,6 +25,8 @@ class Variant < ActiveRecord::Base
   enum reference_build: [:GRCh38, :GRCh37, :NCBI36]
 
   after_initialize :init
+
+  string_to_int_columns :start, :start2, :stop, :stop2
 
   def init
     self.civic_actionability_score ||= 0 if self.has_attribute? :civic_actionability_score

--- a/spec/models/with_string_to_int_columns_spec.rb
+++ b/spec/models/with_string_to_int_columns_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+describe 'WithStringToIntColumns' do
+
+  it 'should define a new class method on the model its mixed into' do
+    expect(Variant.methods.include?(:string_to_int_columns)).to be(true)
+  end
+
+  it 'should remove commas before it casts to int' do
+    variant = Fabricate(:variant)
+
+    variant.start = "1,000,000"
+    variant.save
+    expect(variant.start).to eq(1000000)
+  end
+
+  it 'shouldnt break when an actual int is passed' do
+    variant = Fabricate(:variant)
+
+    variant.start = 1000000
+    variant.save
+    expect(variant.start).to eq(1000000)
+  end
+
+  it 'should work with suggested changes' do
+    variant = Fabricate(:variant)
+    user = Fabricate(:user)
+    applying_user = Fabricate(:user)
+
+    variant.stop = "1,000,000"
+    change = variant.suggest_change!(user, {}, {})
+    change.apply(applying_user, false)
+    variant.reload
+
+    expect(variant.stop).to eq(1000000)
+  end
+end


### PR DESCRIPTION
This adds a new mixin that can be generically used anywhere we're
getting a string from the frontend that we eventually cast to a number.

When mixed in, it defines a class method that allows you to specify
which columns require this treatment. The specified columns will have
their default setter method overidden to remove commas before the
ActiveRecord column casting logic.

closes griffithlab/civic-client#1315