### PR TITLE
Fix FixPubmedEntriesMissingAuthors source query

### DIFF
--- a/app/jobs/fix_pubmed_entries_missing_authors.rb
+++ b/app/jobs/fix_pubmed_entries_missing_authors.rb
@@ -7,8 +7,7 @@ class FixPubmedEntriesMissingAuthors < ApplicationJob
 
   private
   def find_publications_without_authors
-    source_ids_with_authors = Source.joins(:authors).where(source_type: 'PubMed').pluck('sources.id').uniq
-    Source.where.not(id: source_ids_with_authors)
+    Source.left_outer_joins(:authors).where(source_type: 'PubMed').where("authors.id IS NULL").pluck('sources.id')
   end
 
   def get_authors_from_pubmed(sources)


### PR DESCRIPTION
The previous query would first grab all PubMed sources with authors and
then substract that set from all sources. This set would then include
all PubMed sources without authors and all ASCO sources. These sources
would then run through the PubMed scraper, resulting in the scraper
overwriting the data for each ASCO source with the content of the PubMed
publication with the matching citation ID.

The new query will correctly identify only PubMed entries without
authors.

Bonus improvement: we now only execute one query instead of two.

Closes #https://github.com/griffithlab/civic-client/issues/1325