### PR TITLE
Use the nightly civicpy cache pkl location

### DIFF
--- a/app/jobs/create_civic_vcfs.rb
+++ b/app/jobs/create_civic_vcfs.rb
@@ -2,6 +2,7 @@ require 'open3'
 
 class CreateCivicVcfs < ApplicationJob
   def perform
+    ENV['CIVICPY_CACHE_FILE'] = civicpy_cache_file_location
     statuses.each do |description, status_list|
       cmd = ["civicpy", "create-vcf", "--vcf-file-path", vcf_path(description)]
       status_list.each do |status|
@@ -24,5 +25,9 @@ class CreateCivicVcfs < ApplicationJob
       'accepted' => ['accepted'],
       'accepted_and_submitted' => ['accepted', 'submitted'],
     }
+  end
+
+  def civicpy_cache_file_location
+    File.join(Rails.root, 'public', 'downloads', 'nightly', 'nightly-civicpy_cache.pkl')
   end
 end


### PR DESCRIPTION
Currently, CIViCpy would look for the cache pkl file in the default
location ~/.civicpy/cache.pkl. If that file doesn't exit or is
out-of-date, CIViCpy will download the nightly civicpy cache pkl file to
this default location and then use it to create the VCFs.

This is silly when the nightly pkl file lives on
the same machine so this PR sets the CIVICPY_CACHE_FILE environment
variable to point to the nightly pkl file. This will overwrite the default
and result in the nightly pkl file being used directly to create the
VCFs.