### PR TITLE
Add mixin for stripping internal whitespace

### DIFF
--- a/app/models/assertion.rb
+++ b/app/models/assertion.rb
@@ -8,6 +8,7 @@ class Assertion < ActiveRecord::Base
   include Moderated
   include WithCountableEnum
   include WithSingleValueAssociations
+  include WithStrippedWhitespace
 
   belongs_to :gene
   belongs_to :variant
@@ -17,6 +18,8 @@ class Assertion < ActiveRecord::Base
   has_and_belongs_to_many :evidence_items
   has_and_belongs_to_many :drugs
   has_and_belongs_to_many :phenotypes
+
+  columns_with_stripped_whitespace :description
 
   has_one :submission_event,
     ->() { where(action: 'assertion submitted').includes(:originating_user) },

--- a/app/models/concerns/with_stripped_whitespace.rb
+++ b/app/models/concerns/with_stripped_whitespace.rb
@@ -1,0 +1,13 @@
+module WithStrippedWhitespace
+  extend ActiveSupport::Concern
+
+  class_methods do
+    def columns_with_stripped_whitespace(*cols)
+      cols.each do |col|
+        define_method "#{col}=" do |val|
+          super(val.squish)
+        end
+      end
+    end
+  end
+end

--- a/app/models/evidence_item.rb
+++ b/app/models/evidence_item.rb
@@ -8,6 +8,7 @@ class EvidenceItem < ActiveRecord::Base
   include WithCountableEnum
   include Flaggable
   include Commentable
+  include WithStrippedWhitespace
 
   belongs_to :source
   belongs_to :disease
@@ -49,6 +50,8 @@ class EvidenceItem < ActiveRecord::Base
   enum drug_interaction_type: Constants::DRUG_INTERACTION_TYPES
 
   before_save :remove_invalid_drug_associations
+
+  columns_with_stripped_whitespace :description
 
   def self.index_scope
     eager_load(:disease, :source, :drugs, :open_changes)

--- a/app/models/gene.rb
+++ b/app/models/gene.rb
@@ -7,6 +7,7 @@ class Gene < ActiveRecord::Base
   include WithDomainExpertTags
   include Flaggable
   include Commentable
+  include WithStrippedWhitespace
 
   has_many :variants
   has_many :secondary_variants, class_name: 'Variant', foreign_key: 'secondary_gene_id'
@@ -14,6 +15,8 @@ class Gene < ActiveRecord::Base
   has_many :assertions
   has_and_belongs_to_many :sources
   has_and_belongs_to_many :gene_aliases
+
+  columns_with_stripped_whitespace :description
 
   def self.view_scope
     eager_load(:gene_aliases, :sources, variants: [:evidence_items_by_status])

--- a/app/models/variant.rb
+++ b/app/models/variant.rb
@@ -8,6 +8,7 @@ class Variant < ActiveRecord::Base
   include Flaggable
   include Commentable
   include WithStringToIntColumns
+  include WithStrippedWhitespace
 
   belongs_to :gene
   belongs_to :secondary_gene, class_name: 'Gene'
@@ -25,6 +26,8 @@ class Variant < ActiveRecord::Base
   enum reference_build: [:GRCh38, :GRCh37, :NCBI36]
 
   after_initialize :init
+
+  columns_with_stripped_whitespace :description
 
   string_to_int_columns :start, :start2, :stop, :stop2
 

--- a/app/models/variant_group.rb
+++ b/app/models/variant_group.rb
@@ -5,10 +5,13 @@ class VariantGroup < ActiveRecord::Base
   include SoftDeletable
   include Flaggable
   include Commentable
+  include WithStrippedWhitespace
 
   has_many :variant_group_variants
   has_many :variants, through: :variant_group_variants
   has_and_belongs_to_many :sources
+
+  columns_with_stripped_whitespace :description
 
   def self.index_scope
     includes(variants: [:gene, :evidence_items_by_status, :variant_types])

--- a/spec/models/with_stripped_whitespace_spec.rb
+++ b/spec/models/with_stripped_whitespace_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+
+describe 'WithStrippedWhitespace' do
+  it 'should define a new class method on the model its mixed into' do
+    expect(EvidenceItem.methods.include?(:columns_with_stripped_whitespace)).to be(true)
+  end
+
+  it 'should strip internal duplicate spaces and trailing spaces' do
+    e = Fabricate(:evidence_item)
+
+    e.description = '  foo    bar  '
+    e.save
+
+    expect(e.description).to eq('foo bar')
+  end
+
+  it 'should work with suggested changes' do
+    ei = Fabricate(:evidence_item)
+    user = Fabricate(:user)
+    applying_user = Fabricate(:user)
+
+    ei.description = ' foo   bar  '
+    change = ei.suggest_change!(user, {}, {})
+    change.apply(applying_user, false)
+    ei.reload
+
+    expect(ei.description).to eq('foo bar')
+  end
+
+  it 'should strip newlines and tabs' do
+    e = Fabricate(:evidence_item)
+
+    e.description = "foo\tbar\nbaz"
+    e.save
+
+    expect(e.description).to eq('foo bar baz')
+  end
+
+  it 'should work even with aliased columns' do
+    e = Fabricate(:evidence_item)
+
+    e.text = 'foo    bar'
+    e.save
+
+    expect(e.description).to eq('foo bar')
+  end
+end


### PR DESCRIPTION
This creates a mixin which we then use in all of our first class
entities. It overrides the setters of specified model columns to remove
tabs, extraneous spaces, and newlines.

We will want to just run this callback on all existing entities when we
deploy.

Closes griffithlab/civic-client#1017