### PR TITLE
Fix bug in FixPubmedEntriesMissingAuthors

### DIFF
--- a/app/jobs/fix_pubmed_entries_missing_authors.rb
+++ b/app/jobs/fix_pubmed_entries_missing_authors.rb
@@ -7,7 +7,7 @@ class FixPubmedEntriesMissingAuthors < ApplicationJob
 
   private
   def find_publications_without_authors
-    Source.left_outer_joins(:authors).where(source_type: 'PubMed').where("authors.id IS NULL").pluck('sources.id')
+    Source.left_outer_joins(:authors).where(source_type: 'PubMed').where("authors.id IS NULL")
   end
 
   def get_authors_from_pubmed(sources)


### PR DESCRIPTION
The `pluck('sources.id')` would only grab the source id and submit that
to the PubMed Scraper. However, we actually need to submit the source
objects themselves.