### PR TITLE
Pass along "acting as" organization context for pundit

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,6 +13,10 @@ class ApplicationController < ActionController::Base
     after_action :verify_authorized, except: actions
   end
 
+  def pundit_user
+    UserContext.new(current_user, params.dig(:organization, :id))
+  end
+
   private
   def user_not_authorized
     head :forbidden

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -1,11 +1,11 @@
 class Role
   def self.user_is_at_least_a?(user, role)
-    roles = user.class.roles
+    roles = User.roles
     roles[user.role] >= roles[role]
   end
 
   def self.highest_role_for_users(*users)
-    roles = users.first.class.roles
+    roles = User.roles
     users.inject(roles.keys.first) do |max_role, user|
       if roles[user.role] > roles[max_role]
         user.role

--- a/app/models/user_context.rb
+++ b/app/models/user_context.rb
@@ -1,0 +1,12 @@
+class UserContext < DelegateClass(User)
+  attr_reader :acting_as_organization_id
+
+  def initialize(user, organization_id)
+    @acting_as_organization_id = organization_id
+    super(user)
+  end
+
+  def acting_as_organization
+    Organization.find(acting_as_organization_id)
+  end
+end

--- a/app/models/user_context.rb
+++ b/app/models/user_context.rb
@@ -1,9 +1,9 @@
 class UserContext < DelegateClass(User)
-  attr_reader :acting_as_organization_id
+  attr_reader :action_organization
 
   def initialize(user, organization_id)
     numeric_id = Integer(organization_id) rescue nil
-    @acting_as_organization_id = numeric_id
+    @action_organization = numeric_id
     super(user)
   end
 end

--- a/app/models/user_context.rb
+++ b/app/models/user_context.rb
@@ -2,11 +2,8 @@ class UserContext < DelegateClass(User)
   attr_reader :acting_as_organization_id
 
   def initialize(user, organization_id)
-    @acting_as_organization_id = organization_id
+    numeric_id = Integer(organization_id) rescue nil
+    @acting_as_organization_id = numeric_id
     super(user)
-  end
-
-  def acting_as_organization
-    Organization.find(acting_as_organization_id)
   end
 end

--- a/app/policies/assertion_policy.rb
+++ b/app/policies/assertion_policy.rb
@@ -2,22 +2,22 @@ class AssertionPolicy < Struct.new(:user, :assertion)
   include PolicyHelpers
 
   def update?
-    editor_without_coi?(user)
+    editor_without_coi?(user) && belongs_to_acting_as_organization?(user)
   end
 
   def propose?
-    user
+    user && belongs_to_acting_as_organization?(user)
   end
 
   def destroy?
-    editor_without_coi?(user)
+    editor_without_coi?(user) && belongs_to_acting_as_organization?(user)
   end
 
   def accept?
-    editor_without_coi?(user) && assertion.submitter != user
+    editor_without_coi?(user) && assertion.submitter != user && belongs_to_acting_as_organization?(user)
   end
 
   def reject?
-    editor_without_coi?(user) || assertion.submitter == user
+    editor_without_coi?(user) || assertion.submitter == user && belongs_to_acting_as_organization?(user)
   end
 end

--- a/app/policies/assertion_policy.rb
+++ b/app/policies/assertion_policy.rb
@@ -2,22 +2,22 @@ class AssertionPolicy < Struct.new(:user, :assertion)
   include PolicyHelpers
 
   def update?
-    editor_without_coi?(user) && belongs_to_acting_as_organization?(user)
+    editor_without_coi?(user) && belongs_to_action_organization?(user)
   end
 
   def propose?
-    user && belongs_to_acting_as_organization?(user)
+    user && belongs_to_action_organization?(user)
   end
 
   def destroy?
-    editor_without_coi?(user) && belongs_to_acting_as_organization?(user)
+    editor_without_coi?(user) && belongs_to_action_organization?(user)
   end
 
   def accept?
-    editor_without_coi?(user) && assertion.submitter != user && belongs_to_acting_as_organization?(user)
+    editor_without_coi?(user) && assertion.submitter != user && belongs_to_action_organization?(user)
   end
 
   def reject?
-    editor_without_coi?(user) || assertion.submitter == user && belongs_to_acting_as_organization?(user)
+    editor_without_coi?(user) || assertion.submitter == user && belongs_to_action_organization?(user)
   end
 end

--- a/app/policies/comment_policy.rb
+++ b/app/policies/comment_policy.rb
@@ -2,7 +2,7 @@ class CommentPolicy < Struct.new(:user, :comment)
   include PolicyHelpers
 
   def create?
-    user && belongs_to_acting_as_organization?(user)
+    user && belongs_to_action_organization?(user)
   end
 
   def update?

--- a/app/policies/comment_policy.rb
+++ b/app/policies/comment_policy.rb
@@ -2,7 +2,7 @@ class CommentPolicy < Struct.new(:user, :comment)
   include PolicyHelpers
 
   def create?
-    user
+    user && belongs_to_acting_as_organization?(user)
   end
 
   def update?

--- a/app/policies/evidence_item_policy.rb
+++ b/app/policies/evidence_item_policy.rb
@@ -2,22 +2,22 @@ class EvidenceItemPolicy < Struct.new(:user, :evidence_item)
   include PolicyHelpers
 
   def update?
-    editor_without_coi?(user) && belongs_to_acting_as_organization?(user)
+    editor_without_coi?(user) && belongs_to_action_organization?(user)
   end
 
   def propose?
-    user && belongs_to_acting_as_organization?(user)
+    user && belongs_to_action_organization?(user)
   end
 
   def destroy?
-    editor_without_coi?(user) && belongs_to_acting_as_organization?(user)
+    editor_without_coi?(user) && belongs_to_action_organization?(user)
   end
 
   def accept?
-    editor_without_coi?(user) && evidence_item.submitter != user && belongs_to_acting_as_organization?(user)
+    editor_without_coi?(user) && evidence_item.submitter != user && belongs_to_action_organization?(user)
   end
 
   def reject?
-    editor_without_coi?(user) || evidence_item.submitter == user && belongs_to_acting_as_organization?(user)
+    editor_without_coi?(user) || evidence_item.submitter == user && belongs_to_action_organization?(user)
   end
 end

--- a/app/policies/evidence_item_policy.rb
+++ b/app/policies/evidence_item_policy.rb
@@ -2,22 +2,22 @@ class EvidenceItemPolicy < Struct.new(:user, :evidence_item)
   include PolicyHelpers
 
   def update?
-    editor_without_coi?(user)
+    editor_without_coi?(user) && belongs_to_acting_as_organization?(user)
   end
 
   def propose?
-    user
+    user && belongs_to_acting_as_organization?(user)
   end
 
   def destroy?
-    editor_without_coi?(user)
+    editor_without_coi?(user) && belongs_to_acting_as_organization?(user)
   end
 
   def accept?
-    editor_without_coi?(user) && evidence_item.submitter != user
+    editor_without_coi?(user) && evidence_item.submitter != user && belongs_to_acting_as_organization?(user)
   end
 
   def reject?
-    editor_without_coi?(user) || evidence_item.submitter == user
+    editor_without_coi?(user) || evidence_item.submitter == user && belongs_to_acting_as_organization?(user)
   end
 end

--- a/app/policies/flag_policy.rb
+++ b/app/policies/flag_policy.rb
@@ -2,7 +2,7 @@ class FlagPolicy < Struct.new(:user, :flag)
   include PolicyHelpers
 
   def create?
-    user && belongs_to_acting_as_organization?(user)
+    user && belongs_to_action_organization?(user)
   end
 
   def update?

--- a/app/policies/flag_policy.rb
+++ b/app/policies/flag_policy.rb
@@ -2,10 +2,10 @@ class FlagPolicy < Struct.new(:user, :flag)
   include PolicyHelpers
 
   def create?
-    user
+    user && belongs_to_acting_as_organization?(user)
   end
 
   def update?
-    flag.flagging_user == user || editor_without_coi?(user)
+    (flag.flagging_user == user || editor_without_coi?(user))
   end
 end

--- a/app/policies/policy_helpers.rb
+++ b/app/policies/policy_helpers.rb
@@ -9,11 +9,11 @@ module PolicyHelpers
     statement.present? && !statement.expired?
   end
 
-  def belongs_to_acting_as_organization?(user)
-    if user.acting_as_organization_id.nil?
+  def belongs_to_action_organization?(user)
+    if user.action_organization.nil?
       true
     else
-      user.organization_ids.include?(user.acting_as_organization_id)
+      user.organization_ids.include?(user.action_organization)
     end
   end
 end

--- a/app/policies/policy_helpers.rb
+++ b/app/policies/policy_helpers.rb
@@ -8,4 +8,12 @@ module PolicyHelpers
     statement = user.most_recent_conflict_of_interest_statement
     statement.present? && !statement.expired?
   end
+
+  def belongs_to_acting_as_organization?(user)
+    if user.acting_as_organization_id.nil?
+      true
+    else
+      user.organization_ids.include?(user.acting_as_organization_id)
+    end
+  end
 end

--- a/app/policies/policy_helpers.rb
+++ b/app/policies/policy_helpers.rb
@@ -14,7 +14,7 @@ module PolicyHelpers
     if user.action_organization.present? && user.organization_ids.include?(user.action_organization)
       true
     #The user is acting on behalf of an org of which they're not a member
-    elsif user.action_organization.present?
+    elsif user.action_organization.present? && !user.organization_ids.include?(user.action_organization)
       false
     #The user is not acting on behalf of an org
     else

--- a/app/policies/policy_helpers.rb
+++ b/app/policies/policy_helpers.rb
@@ -10,10 +10,15 @@ module PolicyHelpers
   end
 
   def belongs_to_action_organization?(user)
-    if user.action_organization.nil?
+    #The user is acting on behalf of an org of which they're a member
+    if user.action_organization.present? && user.organization_ids.include?(user.action_organization)
       true
+    #The user is acting on behalf of an org of which they're not a member
+    elsif user.action_organization.present?
+      false
+    #The user is not acting on behalf of an org
     else
-      user.organization_ids.include?(user.action_organization)
+      true
     end
   end
 end

--- a/app/policies/source_policy.rb
+++ b/app/policies/source_policy.rb
@@ -1,4 +1,6 @@
 class SourcePolicy < Struct.new(:user, :source)
+  include PolicyHelpers
+
   def create?
     user && belongs_to_acting_as_organization?(user)
   end

--- a/app/policies/source_policy.rb
+++ b/app/policies/source_policy.rb
@@ -2,7 +2,7 @@ class SourcePolicy < Struct.new(:user, :source)
   include PolicyHelpers
 
   def create?
-    user && belongs_to_acting_as_organization?(user)
+    user && belongs_to_action_organization?(user)
   end
 
   def update?

--- a/app/policies/source_policy.rb
+++ b/app/policies/source_policy.rb
@@ -1,6 +1,6 @@
 class SourcePolicy < Struct.new(:user, :source)
   def create?
-    user
+    user && belongs_to_acting_as_organization?(user)
   end
 
   def update?

--- a/app/policies/suggested_change_policy.rb
+++ b/app/policies/suggested_change_policy.rb
@@ -2,19 +2,19 @@ class SuggestedChangePolicy < Struct.new(:user, :suggested_change)
   include PolicyHelpers
 
   def create?
-    user
+    user && belongs_to_acting_as_organization?(user)
   end
 
   def update?
-    suggested_change.user == user ||
-      editor_without_coi?(user)
+    (suggested_change.user == user ||
+      editor_without_coi?(user)) && belongs_to_acting_as_organization?(user)
   end
 
   def accept?
-    editor_without_coi?(user) && suggested_change.user != user
+    editor_without_coi?(user) && suggested_change.user != user && belongs_to_acting_as_organization?(user)
   end
 
   def reject?
-    accept? || suggested_change.user == user
+    accept? || suggested_change.user == user && belongs_to_acting_as_organization?(user)
   end
 end

--- a/app/policies/suggested_change_policy.rb
+++ b/app/policies/suggested_change_policy.rb
@@ -2,19 +2,19 @@ class SuggestedChangePolicy < Struct.new(:user, :suggested_change)
   include PolicyHelpers
 
   def create?
-    user && belongs_to_acting_as_organization?(user)
+    user && belongs_to_action_organization?(user)
   end
 
   def update?
     (suggested_change.user == user ||
-      editor_without_coi?(user)) && belongs_to_acting_as_organization?(user)
+      editor_without_coi?(user)) && belongs_to_action_organization?(user)
   end
 
   def accept?
-    editor_without_coi?(user) && suggested_change.user != user && belongs_to_acting_as_organization?(user)
+    editor_without_coi?(user) && suggested_change.user != user && belongs_to_action_organization?(user)
   end
 
   def reject?
-    accept? || suggested_change.user == user && belongs_to_acting_as_organization?(user)
+    accept? || suggested_change.user == user && belongs_to_action_organization?(user)
   end
 end

--- a/app/policies/variant_group_policy.rb
+++ b/app/policies/variant_group_policy.rb
@@ -2,7 +2,7 @@ class VariantGroupPolicy < Struct.new(:user, :variant_group)
   include PolicyHelpers
 
   def create?
-    user.present?
+    user.present? && belongs_to_acting_as_organization?(user)
   end
 
   def destroy?

--- a/app/policies/variant_group_policy.rb
+++ b/app/policies/variant_group_policy.rb
@@ -2,7 +2,7 @@ class VariantGroupPolicy < Struct.new(:user, :variant_group)
   include PolicyHelpers
 
   def create?
-    user.present? && belongs_to_acting_as_organization?(user)
+    user.present? && belongs_to_action_organization?(user)
   end
 
   def destroy?

--- a/spec/controllers/evidence_item_spec.rb
+++ b/spec/controllers/evidence_item_spec.rb
@@ -36,8 +36,8 @@ describe EvidenceItemsController do
 
   it 'should accept' do
     evidence_item = Fabricate(:evidence_item, status: 'submitted')
-    user = Fabricate(:user, role: :admin)
     org = Fabricate(:organization)
+    user = Fabricate(:user, role: :admin, organizations: [org])
     controller.sign_in(user)
 
     post :accept, params: { evidence_item_id: evidence_item.id, organization: { id: org.id } }

--- a/spec/controllers/subscriptions_spec.rb
+++ b/spec/controllers/subscriptions_spec.rb
@@ -2,31 +2,29 @@ require 'rails_helper'
 
 describe GeneCommentsController do
   it 'should allow for "meta" subscriptions to class/action combinations' do
-    user = Fabricate(:user)
-    gene = Fabricate(:gene)
     org = Fabricate(:organization)
+    user = Fabricate(:user, organizations: [org])
+    gene = Fabricate(:gene)
     OnSiteSubscription.create(user: user, action_type: 'commented', action_class: 'Gene')
     controller.sign_in(user)
 
     post :create, params: { gene_id: gene.id, text: 'test text', title: 'test title', organization: { id: org.id } }
 
     expect(gene.comments.count).to eq 1
-    #expect(Delayed::Worker.new.work_off).to eq [2,0]
     expect(Event.count).to eq 1
     expect(Feed.for_user(user, {}).user).to eq user
   end
 
   it 'should allow for direct subscriptions to "subscribables"' do
-    user = Fabricate(:user)
-    gene = Fabricate(:gene)
     org = Fabricate(:organization)
+    user = Fabricate(:user, organizations: [org])
+    gene = Fabricate(:gene)
     OnSiteSubscription.create(user: user, subscribable: gene)
     controller.sign_in(user)
 
     post :create, params: { gene_id: gene.id, text: 'test text', title: 'test title', organization: { id: org.id } }
 
     expect(gene.comments.count).to eq 1
-    #expect(Delayed::Worker.new.work_off).to eq [2,0]
     expect(Event.count).to eq 1
     expect(Feed.for_user(user, {}).user).to eq user
   end
@@ -34,37 +32,35 @@ end
 
 describe EvidenceItemCommentsController do
   it 'should traverse the hierarchy of subscribables' do
-    user = Fabricate(:user)
+    org = Fabricate(:organization)
+    user = Fabricate(:user, organizations: [org])
     gene = Fabricate(:gene)
     variant = Fabricate(:variant, gene: gene)
     evidence_item = Fabricate(:evidence_item, variant: variant)
-    org = Fabricate(:organization)
     OnSiteSubscription.create(user: user, subscribable: gene)
     controller.sign_in(user)
 
     post :create, params: { evidence_item_id: evidence_item.id, text: 'test text', title: 'test title', organization: { id: org.id } }
 
     expect(evidence_item.comments.count).to eq 1
-    #expect(Delayed::Worker.new.work_off).to eq [2,0]
     expect(Event.count).to eq 1
     expect(Feed.for_user(user, {}).user).to eq user
   end
 
   it 'should only send a single notification for a single event (de-dup subscriptions)' do
-    user = Fabricate(:user)
+    org = Fabricate(:organization)
+    user = Fabricate(:user, organizations: [org])
     gene = Fabricate(:gene)
     variant = Fabricate(:variant, gene: gene)
     evidence_item = Fabricate(:evidence_item, variant: variant)
-    org = Fabricate(:organization)
     OnSiteSubscription.create(user: user, subscribable: gene)
     OnSiteSubscription.create(user: user, subscribable: evidence_item)
     OnSiteSubscription.create(user: user, action_type: 'commented', action_class: 'Gene')
     controller.sign_in(user)
 
-    post :create, params: { evidence_item_id: evidence_item.id, text: 'test text', title: 'test title', organization: { id: org.id } }
+    res = post :create, params: { evidence_item_id: evidence_item.id, text: 'test text', title: 'test title', organization: { id: org.id } }
 
     expect(evidence_item.comments.count).to eq 1
-    #expect(Delayed::Worker.new.work_off).to eq [2,0]
     expect(Event.count).to eq 1
     expect(Feed.for_user(user, {}).user).to eq user
   end


### PR DESCRIPTION
This wraps the `User` object that will be passed to pundit authz checks with additional context from the request. In this case its just the organization that the user is "acting on behalf of" for a particular action but we can imagine expanding that as needed for more complex logic.

This also updates the policies for everything I'm aware of that generates an attributable event to check that either the request hasn't specified an organization to act on behalf of or, if it does, the logged in user is in fact a member.

I am definitely open to suggestions on naming because I really don't like the current one 😀 