### PR TITLE
Only reload objects on data queries, not count queries.

### DIFF
--- a/app/datatables/datatable_base.rb
+++ b/app/datatables/datatable_base.rb
@@ -19,11 +19,9 @@ class DatatableBase
   end
 
   def data
+    ids = filter(order(paginate(select_query))).map {|o| o.id }
+    objects = select_query.where(id: ids)
     objects.map { |o| presenter_class.new(o) }
-  end
-
-  def objects
-    @objects ||= filter(order(paginate(select_query)))
   end
 
   def total_items
@@ -53,8 +51,7 @@ class DatatableBase
       if or_filters.length > 0
         filtered_objects = objects.where(or_filters.join(" OR "), *or_values)
       end
-      ids = filtered_objects.map{|o| o.id}
-      objects.where('id' => ids)
+      filtered_objects
     else
       objects
     end


### PR DESCRIPTION
Closes griffithlab/civic-client#1350

This was related to the change we made to reload the objects from ids. That worked for fetching the data itself, but broke for determining the count of items matching the search criteria (as that query doesn't select a bunch of ids, just a number). So running the `count_query` and mapping over `id` always just returned an empty array. This moves the reload logic to the actual data part and out of the filtering. 