### PR TITLE
Add admin ability to upload user profile images

### DIFF
--- a/app/admin/user.rb
+++ b/app/admin/user.rb
@@ -1,6 +1,6 @@
 ActiveAdmin.register User do
   menu :priority => 2
-  permit_params :name, :email, :username, :url, :orcid, :area_of_expertise, :role, :bio, :featured_expert, :twitter_handle, :linkedin_profile, :facebook_profile, :country_id, organization_ids: []
+  permit_params :name, :email, :username, :url, :orcid, :area_of_expertise, :role, :bio, :featured_expert, :twitter_handle, :linkedin_profile, :facebook_profile, :country_id, :profile_image, organization_ids: []
 
   filter :role
   filter :name
@@ -28,6 +28,7 @@ ActiveAdmin.register User do
       f.input :organizations, collection: Organization.order(:name), include_blank: false
       f.input :role, as: :select, collection: User.roles.keys, include_blank: false
       f.input :country
+      f.input :profile_image, as: :file
     end
     f.actions
   end


### PR DESCRIPTION
This ended up being straightforward as when I added the ability for orgs to have uploaded profile images, I stubbed in the implementation for users as well. (see https://github.com/griffithlab/civic-server/blob/staging/app/models/user.rb#L35, https://github.com/griffithlab/civic-server/blob/staging/app/presenters/user_presenter.rb#L45, and https://github.com/griffithlab/civic-server/blob/staging/db/migrate/20170512211026_custom_user_profile_images.rb). 

This simply adds an admin form entry to allow upload. Uploaded images will override gravatars.