### PR TITLE
Only update/set a variant's allele registry ID if API query returned one

### DIFF
--- a/app/jobs/set_allele_registry_ids.rb
+++ b/app/jobs/set_allele_registry_ids.rb
@@ -8,7 +8,7 @@ class SetAlleleRegistryIds < AlleleRegistryIds
       if allele_registry_id == '_:CA'
         v.allele_registry_id = 'unregistered'
         v.save
-      else
+      elsif not allele_registry_id.nil?
         v.allele_registry_id = allele_registry_id
         v.save
         add_allele_registry_link(allele_registry_id)

--- a/app/jobs/set_allele_registry_ids.rb
+++ b/app/jobs/set_allele_registry_ids.rb
@@ -8,7 +8,7 @@ class SetAlleleRegistryIds < AlleleRegistryIds
       if allele_registry_id == '_:CA'
         v.allele_registry_id = 'unregistered'
         v.save
-      elsif not allele_registry_id.nil?
+      elsif allele_registry_id.present?
         v.allele_registry_id = allele_registry_id
         v.save
         add_allele_registry_link(allele_registry_id)

--- a/app/jobs/update_allele_registry_ids.rb
+++ b/app/jobs/update_allele_registry_ids.rb
@@ -10,7 +10,7 @@ class UpdateAlleleRegistryIds < AlleleRegistryIds
         if allele_registry_id == '_:CA'
           v.allele_registry_id = 'unregistered'
           v.save
-        elsif not allele_registry_id.nil?
+        elsif allele_registry_id.present?
           v.allele_registry_id = allele_registry_id
           v.save
           add_allele_registry_link(allele_registry_id)

--- a/app/jobs/update_allele_registry_ids.rb
+++ b/app/jobs/update_allele_registry_ids.rb
@@ -10,7 +10,7 @@ class UpdateAlleleRegistryIds < AlleleRegistryIds
         if allele_registry_id == '_:CA'
           v.allele_registry_id = 'unregistered'
           v.save
-        else
+        elsif not allele_registry_id.nil?
           v.allele_registry_id = allele_registry_id
           v.save
           add_allele_registry_link(allele_registry_id)


### PR DESCRIPTION
This is related to https://github.com/griffithlab/civic-client/issues/1395 but doesn't cause any fatal errors so wouldn't be the reason for variants not getting their allele registry id set. However, this will improve runtime drastically.