### PR TITLE
Replace the unused `objects` method with a `data` method

### DIFF
--- a/app/datatables/user_browse_table.rb
+++ b/app/datatables/user_browse_table.rb
@@ -33,8 +33,10 @@ class UserBrowseTable < DatatableBase
     filtered_query
   end
 
-  def objects
-    @limited_objects ||= limit(super)
+  def data
+    ids = limit(filter(order(paginate(select_query)))).map {|o| o.id }
+    objects = select_query.where(id: ids)
+    objects.map { |o| presenter_class.new(o) }
   end
 
   def total_items


### PR DESCRIPTION
The previous `objects` method never got called so the `limit` function
never got applied to the list of users. The `data` function is now
overwritten from the default to apply the `limit` method.

Closes https://github.com/griffithlab/civic-client/issues/1412