### PR TITLE
Fix broken filters on evidence item and assertion browse tables

### DIFF
--- a/app/datatables/assertion_browse_table.rb
+++ b/app/datatables/assertion_browse_table.rb
@@ -28,23 +28,23 @@ class AssertionBrowseTable < DatatableBase
     'evidence_item_count' => 'evidence_item_count',
   }
 
+  def special_filters
+    ['evidence_type', 'evidence_direction', 'clinical_significance', 'variant_origin']
+  end
+
   def filter(objects)
     filtered_query = objects.dup
     if evidence_type = extract_filter_term('evidence_type')
       filtered_query = filtered_query.where(evidence_type: Assertion.evidence_types[evidence_type])
-      params['filter'].delete('evidence_type')
     end
     if evidence_direction = extract_filter_term('evidence_direction')
       filtered_query = filtered_query.where(evidence_direction: Assertion.evidence_directions[evidence_direction])
-      params['filter'].delete('evidence_direction')
     end
     if clinical_significance = extract_filter_term('clinical_significance')
       filtered_query = filtered_query.where(clinical_significance: Assertion.clinical_significances[clinical_significance])
-      params['filter'].delete('clinical_significance')
     end
     if variant_origin = extract_filter_term('variant_origin')
       filtered_query = filtered_query.where(variant_origin: Assertion.variant_origins[variant_origin])
-      params['filter'].delete('variant_origin')
     end
     super(filtered_query)
   end

--- a/app/datatables/datatable_base.rb
+++ b/app/datatables/datatable_base.rb
@@ -34,9 +34,7 @@ class DatatableBase
 
   def filter(objects)
     if params['filter']
-      filter_params = params['filter'].reject{|name, value| special_filters.include? name}
-    end
-    if filter_params
+      filter_params = params['filter'].reject{|name, _| special_filters.include? name}
       or_filters = []
       or_values = []
       filtered_objects = filter_params.inject(objects) do |o, (col, term)|

--- a/app/datatables/datatable_base.rb
+++ b/app/datatables/datatable_base.rb
@@ -33,7 +33,10 @@ class DatatableBase
   end
 
   def filter(objects)
-    if filter_params = params['filter']
+    if params['filter']
+      filter_params = params['filter'].reject{|name, value| special_filters.include? name}
+    end
+    if filter_params
       or_filters = []
       or_values = []
       filtered_objects = filter_params.inject(objects) do |o, (col, term)|
@@ -118,6 +121,10 @@ class DatatableBase
   end
 
   def count_query
+    raise 'Must implement in subclass'
+  end
+
+  def special_filters
     raise 'Must implement in subclass'
   end
 end

--- a/app/datatables/evidence_item_browse_table.rb
+++ b/app/datatables/evidence_item_browse_table.rb
@@ -36,31 +36,29 @@ class EvidenceItemBrowseTable < DatatableBase
     'rating' => 'evidence_items.rating',
   }
 
+  def special_filters
+    ['evidence_level', 'evidence_type', 'evidence_direction', 'clinical_significance', 'variant_origin', 'rating']
+  end
+
   def filter(objects)
     filtered_query = objects.dup
     if evidence_level = extract_filter_term('evidence_level')
       filtered_query = filtered_query.where(evidence_level: EvidenceItem.evidence_levels[evidence_level])
-      params['filter'].delete('evidence_level')
     end
     if evidence_type = extract_filter_term('evidence_type')
       filtered_query = filtered_query.where(evidence_type: EvidenceItem.evidence_types[evidence_type])
-      params['filter'].delete('evidence_type')
     end
     if evidence_direction = extract_filter_term('evidence_direction')
       filtered_query = filtered_query.where(evidence_direction: EvidenceItem.evidence_directions[evidence_direction])
-      params['filter'].delete('evidence_direction')
     end
     if clinical_significance = extract_filter_term('clinical_significance')
       filtered_query = filtered_query.where(clinical_significance: EvidenceItem.clinical_significances[clinical_significance])
-      params['filter'].delete('clinical_significance')
     end
     if variant_origin = extract_filter_term('variant_origin')
       filtered_query = filtered_query.where(variant_origin: EvidenceItem.variant_origins[variant_origin])
-      params['filter'].delete('variant_origin')
     end
     if rating = extract_filter_term('rating')
       filtered_query = filtered_query.where(rating: rating)
-      params['filter'].delete('rating')
     end
     super(filtered_query)
   end

--- a/app/datatables/gene_browse_table.rb
+++ b/app/datatables/gene_browse_table.rb
@@ -35,4 +35,8 @@ class GeneBrowseTable < DatatableBase
   def count_query
     initial_scope.select('COUNT(DISTINCT(genes.id)) as count')
   end
+
+  def special_filters
+    []
+  end
 end

--- a/app/datatables/organization_browse_table.rb
+++ b/app/datatables/organization_browse_table.rb
@@ -54,6 +54,10 @@ class OrganizationBrowseTable < DatatableBase
     initial_scope.select('COUNT(DISTINCT(organizations.id)) as count')
   end
 
+  def special_filters
+    []
+  end
+
   private
   def time_from_term(term)
     Constants::TIMESPAN_MAP[term]

--- a/app/datatables/source_browse_table.rb
+++ b/app/datatables/source_browse_table.rb
@@ -36,4 +36,8 @@ class SourceBrowseTable < DatatableBase
   def count_query
     initial_scope.select('COUNT(DISTINCT(sources.id)) as count')
   end
+
+  def special_filters
+    []
+  end
 end

--- a/app/datatables/source_suggestion_browse_table.rb
+++ b/app/datatables/source_suggestion_browse_table.rb
@@ -33,4 +33,8 @@ class SourceSuggestionBrowseTable < DatatableBase
       .select('COUNT(DISTINCT(source_suggestions.id)) as count')
       .group('source_suggestions.id')
   end
+
+  def special_filters
+    []
+  end
 end

--- a/app/datatables/variant_browse_table.rb
+++ b/app/datatables/variant_browse_table.rb
@@ -37,4 +37,8 @@ class VariantBrowseTable < DatatableBase
     initial_scope.select('COUNT(DISTINCT(variants.id)) as count')
       .where("evidence_items.status != 'rejected'")
   end
+
+  def special_filters
+    []
+  end
 end

--- a/app/datatables/variant_group_browse_table.rb
+++ b/app/datatables/variant_group_browse_table.rb
@@ -31,4 +31,8 @@ class VariantGroupBrowseTable < DatatableBase
   def count_query
     initial_scope.select('COUNT(DISTINCT(variant_groups.id)) as count')
   end
+
+  def special_filters
+    []
+  end
 end


### PR DESCRIPTION
Closes https://github.com/griffithlab/civic-client/issues/1419

The evidence item and assertion browse table backends had some special logic baked in to handle enums like the evidence type, clinical significance, etc. However, when applying that special logic it would subsequently delete the parameter for that filter so it wouldn't try to also apply these filters again during the generic filtering logic. This would cause these filters to be missing when the total was being calculated. 

This change removes the deleting of these filter parameters from the parameter hash and instead implements an alternate approach on how to skip these type of filter parameters during the main filtering logic.