### PR TITLE
Update Sequence Ontology obo file location

### DIFF
--- a/app/jobs/update_sequence_ontology.rb
+++ b/app/jobs/update_sequence_ontology.rb
@@ -34,6 +34,6 @@ class UpdateSequenceOntology < ApplicationJob
   end
 
   def latest_soid_path
-    "https://raw.githubusercontent.com/The-Sequence-Ontology/SO-Ontologies/master/releases/so-xp.owl/so.obo"
+    "https://raw.githubusercontent.com/The-Sequence-Ontology/SO-Ontologies/master/Ontology_Files/so.obo"
   end
 end


### PR DESCRIPTION
The Sequence Ontology restructured their repo and changed the file names and location in the process. If someone could confirm that this is indeed the file we want to import, that would be great.