### PR TITLE
Fix error when trying to update user profile

### DIFF
--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -1,9 +1,9 @@
 class UserPolicy < Struct.new(:current_user, :target_user)
   def update?
-    target_user == current_user || Role.user_is_at_least_a?(user, :admin)
+    target_user == current_user || Role.user_is_at_least_a?(current_user, :admin)
   end
 
   def destroy?
-    target_user == current_user || Role.user_is_at_least_a?(user, :admin)
+    target_user == current_user || Role.user_is_at_least_a?(current_user, :admin)
   end
 end


### PR DESCRIPTION
I'm actually super confused how this used to ever work but I think this might've been caused with some changes we recently made to user permission tracking for different activities as part of the multi-user org feature. I think `@user` went away as part of that update. This change seems to work though.

Closes https://github.com/griffithlab/civic-client/issues/1426