### PR TITLE
Fix org stats to count correctly by Event org and not by users

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -36,7 +36,7 @@ class Organization < ActiveRecord::Base
   end
 
   def org_and_suborg_ids
-    return [self.id] + self.groups.map{|g| g.id}
+    return [self.id] + self.group_ids
   end
 
   def all_users


### PR DESCRIPTION
Closes https://github.com/griffithlab/civic-client/issues/1433

Previously, we would take all of the users of an organization and add their stats together. Now that a user can be part of multiple orgs we need to actually look at the Event and only count the one attribute to this organization.