### PR TITLE
Fix browse grid sorting

### DIFF
--- a/app/datatables/datatable_base.rb
+++ b/app/datatables/datatable_base.rb
@@ -20,7 +20,7 @@ class DatatableBase
 
   def data
     ids = filter(order(paginate(select_query))).map {|o| o.id }
-    objects = select_query.where(id: ids)
+    objects = order(select_query.where(id: ids))
     objects.map { |o| presenter_class.new(o) }
   end
 

--- a/app/datatables/user_browse_table.rb
+++ b/app/datatables/user_browse_table.rb
@@ -35,7 +35,7 @@ class UserBrowseTable < DatatableBase
 
   def data
     ids = limit(filter(order(paginate(select_query)))).map {|o| o.id }
-    objects = select_query.where(id: ids)
+    objects = order(select_query.where(id: ids))
     objects.map { |o| presenter_class.new(o) }
   end
 


### PR DESCRIPTION
Needed to apply the same ordering to the selected ids, otherwise we got the correct ids for that page based on the ordering, but they wouldn't be correctly ordered within the page.

closes griffithlab/civic-client#1412 and also fixes the sort issues on the various browse grids.