### PR TITLE
Training server

### DIFF
--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -3,7 +3,11 @@ class LinksController < ApplicationController
   skip_analytics :redirect
 
   def redirect
-    router = FrontendRouter.new(params[:idtype] || params[:idType], params[:id])
+    router = FrontendRouter.new(
+      params[:idtype] || params[:idType],
+      params[:id],
+      request.base_url
+    )
     url = router.url
     if url.blank?
       head :bad_request

--- a/app/models/frontend_router.rb
+++ b/app/models/frontend_router.rb
@@ -1,8 +1,10 @@
 class FrontendRouter
-  attr_reader :id_type, :id
-  def initialize(id_type, id)
+  attr_reader :id_type, :id, :domain
+
+  def initialize(id_type, id, domain)
     @id_type = id_type || ''
     @id = id
+    @domain = domain
   end
 
   def url
@@ -60,9 +62,5 @@ class FrontendRouter
     else
       []
     end
-  end
-
-  def domain
-    'https://civicdb.org/'
   end
 end

--- a/config/deploy/training.rb
+++ b/config/deploy/training.rb
@@ -1,0 +1,13 @@
+server "44.229.206.217", user: 'ubuntu', roles: %w{web db app}
+
+set :rbenv_ruby, '2.6.6'
+
+set :branch, 'master'
+
+set :linked_files, fetch(:linked_files, []).push('public/assets/images/favicon.png')
+
+set :ssh_options, {
+  keys: ENV['CIVIC_TRAINING_KEY'],
+  forward_agent: false,
+  auth_methods: %w(publickey)
+}


### PR DESCRIPTION
This PR sets up stuff for the new training server.

* It changes the routing code used in the shortlinks to use the domain the request came from instead of always redirecting to civicdb.org

* It adds a new cap deployment for the training server that will deploy from the master branch to match what's deployed to prod (as opposed to staging). In order for `cap training deploy` to work, developers will need to set the ENV variable to point to the appropriate `.pem` file which I've sent to them.