### PR TITLE
Support paginated presenter

### DIFF
--- a/app/controllers/advanced_search_controller.rb
+++ b/app/controllers/advanced_search_controller.rb
@@ -9,13 +9,18 @@ class AdvancedSearchController < ApplicationController
                :new
              end
 
+
     search = AdvancedSearch.send(
       method,
       params: params,
       search_type: search_model
     )
 
-    render json: AdvancedSearchPresenter.new(search)
+    if params['count'].present?
+      render json: PaginatedAdvancedSearchPresenter.new(search, request)
+    else
+      render json: AdvancedSearchPresenter.new(search)
+    end
   end
 
   def show
@@ -24,7 +29,12 @@ class AdvancedSearchController < ApplicationController
       search_type: search_model_for_request.to_s
     )
 
-    render json: AdvancedSearchPresenter.new(search)
+    if search.params['count']
+      render json: PaginatedAdvancedSearchPresenter.new(search, request)
+    else
+      render json: AdvancedSearchPresenter.new(search)
+    end
+
   end
 
   private

--- a/app/models/advanced_searches/evidence_item.rb
+++ b/app/models/advanced_searches/evidence_item.rb
@@ -5,7 +5,7 @@ module AdvancedSearches
     def initialize(params)
       @params = params
 
-      @presentation_class = if params['grid-view'] == true
+      @presentation_class = if params['gridView'] == true
         MinimalEvidenceGridPresenter
       else
         EvidenceItemWithStateParamsPresenter

--- a/app/presenters/paginated_advanced_search_presenter.rb
+++ b/app/presenters/paginated_advanced_search_presenter.rb
@@ -1,0 +1,24 @@
+class PaginatedAdvancedSearchPresenter
+  attr_reader :saved_search, :request
+
+  def initialize(saved_search, request)
+    @saved_search = saved_search
+    @request = request
+  end
+
+  def as_json(opt = {})
+    searcher = saved_search.searcher
+    query = searcher.search
+    {
+      _meta: PaginationPresenter.new(query, [], request),
+      params: saved_search.params.as_json,
+      token: saved_search.token,
+      results: results(query, searcher.presentation_class)
+    }
+  end
+
+  private
+  def results(query, presenter)
+      query.map { |r| presenter.new(r) }
+  end
+end


### PR DESCRIPTION
The advanced search endpoint already supported pagination parameters (`page` and `count`) this will wrap the response in the same type of pagination presenter we use elsewhere (containing links to previous and next pages, etc).

The caveat here is that the search parameters themselves are transmitted in the body since its a `POST` request, so a user will need to iterate over the pages as normal (`while _meta[links][next] != null` or whatever) but still include the contents from `response['params']` in the subsequent requests.

We may want to work on a better interface than this, but it should be okay for now as long as we document that behavior.