### PR TITLE
Direct object comparison always fails, use id instead

### DIFF
--- a/app/policies/assertion_policy.rb
+++ b/app/policies/assertion_policy.rb
@@ -14,10 +14,10 @@ class AssertionPolicy < Struct.new(:user, :assertion)
   end
 
   def accept?
-    editor_without_coi?(user) && assertion.submitter != user && belongs_to_action_organization?(user)
+    editor_without_coi?(user) && assertion.submitter.id != user.id && belongs_to_action_organization?(user)
   end
 
   def reject?
-    editor_without_coi?(user) || assertion.submitter == user && belongs_to_action_organization?(user)
+    editor_without_coi?(user) || assertion.submitter.id == user.id && belongs_to_action_organization?(user)
   end
 end

--- a/app/policies/comment_policy.rb
+++ b/app/policies/comment_policy.rb
@@ -6,7 +6,7 @@ class CommentPolicy < Struct.new(:user, :comment)
   end
 
   def update?
-    editor_without_coi?(user) || user == comment.user
+    editor_without_coi?(user) || user.id == comment.user.id
   end
 
   def destroy?

--- a/app/policies/domain_expert_tag_policy.rb
+++ b/app/policies/domain_expert_tag_policy.rb
@@ -5,6 +5,6 @@ class DomainExpertTagPolicy < Struct.new(:user, :tag)
 
   def destroy?
     user.present? &&
-      (tag.user == user || Role.user_is_at_least_a?(user, :admin))
+      (tag.user.id == user.id || Role.user_is_at_least_a?(user, :admin))
   end
 end

--- a/app/policies/evidence_item_policy.rb
+++ b/app/policies/evidence_item_policy.rb
@@ -14,10 +14,10 @@ class EvidenceItemPolicy < Struct.new(:user, :evidence_item)
   end
 
   def accept?
-    editor_without_coi?(user) && evidence_item.submitter != user && belongs_to_action_organization?(user)
+    editor_without_coi?(user) && evidence_item.submitter.id != user.id && belongs_to_action_organization?(user)
   end
 
   def reject?
-    editor_without_coi?(user) || evidence_item.submitter == user && belongs_to_action_organization?(user)
+    editor_without_coi?(user) || evidence_item.submitter.id == user.id && belongs_to_action_organization?(user)
   end
 end

--- a/app/policies/flag_policy.rb
+++ b/app/policies/flag_policy.rb
@@ -6,6 +6,6 @@ class FlagPolicy < Struct.new(:user, :flag)
   end
 
   def update?
-    (flag.flagging_user == user || editor_without_coi?(user))
+    (flag.flagging_user.id == user.id || editor_without_coi?(user))
   end
 end

--- a/app/policies/notification_policy.rb
+++ b/app/policies/notification_policy.rb
@@ -1,5 +1,5 @@
 class NotificationPolicy < Struct.new(:user, :notification)
   def update?
-    Role.user_is_at_least_a?(user, :admin) || notification.notified_user == user
+    Role.user_is_at_least_a?(user, :admin) || notification.notified_user.id == user.id
   end
 end

--- a/app/policies/subscription_policy.rb
+++ b/app/policies/subscription_policy.rb
@@ -5,7 +5,7 @@ class SubscriptionPolicy < Struct.new(:user, :subscription)
 
   def show?
     user.present? &&
-      (subscription.user == user || Role.user_is_at_least_a?(user, :admin))
+      (subscription.user.id == user.id || Role.user_is_at_least_a?(user, :admin))
   end
 
   def create?
@@ -14,6 +14,6 @@ class SubscriptionPolicy < Struct.new(:user, :subscription)
 
   def destroy?
     user.present? &&
-      (subscription.user == user || Role.user_is_at_least_a?(user, :admin))
+      (subscription.user.id == user.id || Role.user_is_at_least_a?(user, :admin))
   end
 end

--- a/app/policies/suggested_change_policy.rb
+++ b/app/policies/suggested_change_policy.rb
@@ -6,15 +6,15 @@ class SuggestedChangePolicy < Struct.new(:user, :suggested_change)
   end
 
   def update?
-    (suggested_change.user == user ||
+    (suggested_change.user.id == user.id ||
       editor_without_coi?(user)) && belongs_to_action_organization?(user)
   end
 
   def accept?
-    editor_without_coi?(user) && suggested_change.user != user && belongs_to_action_organization?(user)
+    editor_without_coi?(user) && suggested_change.user.id != user.id && belongs_to_action_organization?(user)
   end
 
   def reject?
-    accept? || suggested_change.user == user && belongs_to_action_organization?(user)
+    accept? || suggested_change.user.id == user.id && belongs_to_action_organization?(user)
   end
 end

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -1,9 +1,9 @@
 class UserPolicy < Struct.new(:current_user, :target_user)
   def update?
-    target_user == current_user || Role.user_is_at_least_a?(current_user, :admin)
+    target_user.id == current_user.id || Role.user_is_at_least_a?(current_user, :admin)
   end
 
   def destroy?
-    target_user == current_user || Role.user_is_at_least_a?(current_user, :admin)
+    target_user.id == current_user.id || Role.user_is_at_least_a?(current_user, :admin)
   end
 end

--- a/spec/controllers/evidence_item_spec.rb
+++ b/spec/controllers/evidence_item_spec.rb
@@ -35,7 +35,7 @@ describe EvidenceItemsController do
   end
 
   it 'should accept' do
-    evidence_item = Fabricate(:evidence_item, status: 'submitted')
+    evidence_item = Fabricate(:evidence_item, status: 'submitted', submitter: Fabricate(:user))
     org = Fabricate(:organization)
     user = Fabricate(:user, role: :admin, organizations: [org])
     controller.sign_in(user)
@@ -47,6 +47,7 @@ describe EvidenceItemsController do
   end
 
   it 'should reject' do
+    evidence_item = Fabricate(:evidence_item, status: 'submitted', submitter: Fabricate(:user))
     evidence_item = Fabricate(:evidence_item, status: 'submitted')
     user = Fabricate(:user, role: :admin)
     org = Fabricate(:organization)


### PR DESCRIPTION
Apparently the `target_user` and the `current_user` have different `object_id`s so the direct comparison always fails. Comparing by `id` does the trick.