### PR TITLE
account for organization field potentially not existing

### DIFF
--- a/app/presenters/lifecycle_presenter.rb
+++ b/app/presenters/lifecycle_presenter.rb
@@ -13,7 +13,7 @@ class LifecyclePresenter
                else
                  event.user
                end
-        organization = if event.organization.nil?
+        organization = if event.try(:organization).nil?
                          {}
                        else
                          OrganizationIndexPresenter.new(event.organization)


### PR DESCRIPTION
This is a quick fix for the error that's being thrown on variant group pages just to get it working again. 

Longer/medium term we'll need to determine a course of action for variant groups in general to address the underlying issue. Do they get promoted to full civic entities with a real lifecycle? Do planned 2.0 features subsume them and we get rid of them? 

closes griffithlab/civic-client#1463