### PR TITLE
Return 404 when an id isn't found

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,6 +7,7 @@ class ApplicationController < ActionController::Base
   include RateLimited
 
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
+  rescue_from ActiveRecord::RecordNotFound, with: :not_found
 
   def self.actions_without_auth(*actions)
     skip_before_action :ensure_signed_in, only: actions
@@ -20,5 +21,9 @@ class ApplicationController < ActionController::Base
   private
   def user_not_authorized
     head :forbidden
+  end
+
+  def not_found
+    head :not_found
   end
 end


### PR DESCRIPTION
Currently when we call `find_by`, if the id doesn't exist, we get an error. Instead we should catch that error and return a 404 to be more idiomatic.

This will address errors in airbrake of the following style:

https://griffithlab-apps.airbrake.io/projects/285901/groups/2826758699422111844/notices/2826758673858709132
https://griffithlab-apps.airbrake.io/projects/285901/groups/2815961221013757690?tab=overview

etc.

Basically anything that's currently throwing an `ActiveRecord::NotFound` exception