### PR TITLE
Handle case where /id/ matches but its not a valid id

### DIFF
--- a/app/models/frontend_router.rb
+++ b/app/models/frontend_router.rb
@@ -43,7 +43,11 @@ class FrontendRouter
     when /allele_registry/
       [ Variant, :allele_registry_id, ]
     when /id/
-      type, parsed_id = id.upcase.match(/^(AID|GID|VID|EID|SID)(\d+)$/).captures
+      type, parsed_id = if match = id.upcase.match(/^(AID|GID|VID|EID|SID)(\d+)$/)
+                           match.captures
+                         else
+                           []
+                         end
       id = parsed_id
       case type
       when "AID"


### PR DESCRIPTION
This will address:

https://griffithlab-apps.airbrake.io/projects/285901/groups/2825207910287333077

Basically a shortlink that matches the `/id/` regex but doesn't actually resolve to a valid format (EID, AID, etc. The regex would return `nil` and then calling `.captures` on `nil` would error out.