### PR TITLE
Add initial support for reverting EIDs to submitted status

### DIFF
--- a/app/controllers/evidence_items_controller.rb
+++ b/app/controllers/evidence_items_controller.rb
@@ -75,6 +75,17 @@ class EvidenceItemsController < ApplicationController
     update_status(:reject)
   end
 
+  def revert
+    item = EvidenceItem.view_scope.find_by!(id: params[:evidence_item_id])
+    authorize item
+    result = item.revert(current_user, params[:organization])
+    if result.succeeded?
+      render json: EvidenceItemDetailPresenter.new(result.evidence_item)
+    else
+      render json: { errors: result.errors }, status: :bad_request
+    end
+  end
+
   def show
     item = EvidenceItem.view_scope
       .find_by!(id: params[:id])

--- a/app/models/actions/revert_evidence_item.rb
+++ b/app/models/actions/revert_evidence_item.rb
@@ -15,7 +15,6 @@ module Actions
     def execute
       evidence_item.lock!
       if evidence_item.status != 'submitted'
-        update_source_status
         update_variant_score
         evidence_item.status = 'submitted'
         evidence_item.save!

--- a/app/models/actions/revert_evidence_item.rb
+++ b/app/models/actions/revert_evidence_item.rb
@@ -1,0 +1,37 @@
+module Actions
+  class RevertEvidenceItem
+    include Actions::Transactional
+    include Actions::WithEvent
+    attr_reader :evidence_item, :subject, :originating_user, :organization
+
+    def initialize(evidence_item, originating_user, organization)
+      @evidence_item = evidence_item
+      @subject = evidence_item
+      @originating_user = originating_user
+      @organization = organization
+    end
+
+    private
+    def execute
+      evidence_item.lock!
+      if evidence_item.status != 'submitted'
+        update_source_status
+        update_variant_score
+        evidence_item.status = 'submitted'
+        evidence_item.save!
+        create_event('reverted')
+        evidence_item.subscribe_user(originating_user)
+      else
+        errors << "Attempted to revert evidence item to submitted, but it already is."
+      end
+    end
+
+    def update_variant_score
+      UpdateVariantScore.perform_later(evidence_item.variant)
+    end
+
+    def state_params
+      evidence_item.state_params
+    end
+  end
+end

--- a/app/models/evidence_item.rb
+++ b/app/models/evidence_item.rb
@@ -134,6 +134,15 @@ class EvidenceItem < ActiveRecord::Base
     cmd.perform
   end
 
+  def revert(reverting_user, organization)
+    cmd = Actions::RevertEvidenceItem.new(
+      self,
+      reverting_user,
+      organization
+    )
+    cmd.perform
+  end
+
   def additional_changes_info
     @@additional_drug_changes ||= {
       'drugs' => {

--- a/app/policies/evidence_item_policy.rb
+++ b/app/policies/evidence_item_policy.rb
@@ -20,4 +20,8 @@ class EvidenceItemPolicy < Struct.new(:user, :evidence_item)
   def reject?
     editor_without_coi?(user) || evidence_item.submitter.id == user.id && belongs_to_action_organization?(user)
   end
+
+  def revert?
+    editor_without_coi?(user) && belongs_to_action_organization?(user)
+  end
 end

--- a/app/presenters/event_presenter.rb
+++ b/app/presenters/event_presenter.rb
@@ -74,6 +74,8 @@ class EventPresenter
         '%s accepted an assertion'
       when 'assertion rejected'
         '%s rejected an assertion'
+      when 'reverted'
+        '%s reverted an evidence item to submitted'
       else
         raise 'Unexpected event type found!'
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -119,6 +119,7 @@ Rails.application.routes.draw do
       concerns :advanced_search
       post 'accept' => 'evidence_items#accept'
       post 'reject' => 'evidence_items#reject'
+      post 'revert' => 'evidence_items#revert'
     end
 
     resources 'assertions', except: [:new, :create, :edit] do


### PR DESCRIPTION
Looking at `stats_hash` in the User and Organization models, as well as the leaderboard code, it appears that actually we don't need to change anything there to get correct calculations, but I'd appreciate a second set of eyes on that. 