### PR TITLE
Add a flagged status column to flaggable entities

### DIFF
--- a/app/models/actions/flag_entity.rb
+++ b/app/models/actions/flag_entity.rb
@@ -15,6 +15,7 @@ module Actions
     private
     def execute
       create_flag
+      mark_as_flagged
       create_event('flagged')
       subscribe_user
     end
@@ -25,6 +26,11 @@ module Actions
         flaggable: flaggable,
         state: 'open'
       ).first_or_create
+    end
+
+    def mark_as_flagged
+      flaggable.flagged = true
+      flaggable.save
     end
 
     def state_params

--- a/app/models/actions/resolve_flag.rb
+++ b/app/models/actions/resolve_flag.rb
@@ -14,6 +14,7 @@ module Actions
     private
     def execute
       resolve_flag
+      update_status
       create_event('flag resolved')
     end
 
@@ -21,6 +22,13 @@ module Actions
       flag.state = 'resolved'
       flag.resolving_user = originating_user
       flag.save
+    end
+
+    def update_status
+      if flaggable.flags.all? { |f| f.status == 'resolved' }
+        flaggable.flagged = false
+        flaggable.save
+      end
     end
 
     def state_params

--- a/app/models/concerns/flaggable.rb
+++ b/app/models/concerns/flaggable.rb
@@ -7,14 +7,5 @@ module Flaggable
       ->() { order('created_at DESC') },
       class_name: 'Flag',
       as: :flaggable
-
-
-    def current_flag_status
-      if most_recent_flag.present?
-        most_recent_flag.state
-      else
-        'unflagged'
-      end
-    end
   end
 end

--- a/app/presenters/assertion_index_presenter.rb
+++ b/app/presenters/assertion_index_presenter.rb
@@ -24,6 +24,7 @@ class AssertionIndexPresenter
       status: assertion.status,
       open_change_count: assertion.open_changes.size,
       pending_evidence_count: assertion.pending_evidence.size,
+      flagged: assertion.flagged
     }
   end
 end

--- a/app/presenters/evidence_item_index_presenter.rb
+++ b/app/presenters/evidence_item_index_presenter.rb
@@ -23,6 +23,7 @@ class EvidenceItemIndexPresenter
         open_change_count: item.open_changes.size,
         type: :evidence,
         source: SourcePresenter.new(item.source),
+        flagged: item.flagged,
         variant_id: item.variant_id,
         phenotypes: item.phenotypes.map { |p| PhenotypePresenter.new(p) }
     }

--- a/app/presenters/gene_index_presenter.rb
+++ b/app/presenters/gene_index_presenter.rb
@@ -11,6 +11,7 @@ class GeneIndexPresenter
       name: gene.name,
       entrez_id: gene.entrez_id,
       description: gene.description,
+      flagged: gene.flagged,
       variants: variants,
       aliases: gene.gene_aliases.map(&:name),
       type: :gene

--- a/app/presenters/variant_group_index_presenter.rb
+++ b/app/presenters/variant_group_index_presenter.rb
@@ -12,6 +12,7 @@ class VariantGroupIndexPresenter
       description: variant_group.description,
       variants: variants,
       type: :variant_group,
+      flagged: variant_group.flagged
     }
   end
 

--- a/app/presenters/variant_index_presenter.rb
+++ b/app/presenters/variant_index_presenter.rb
@@ -16,6 +16,7 @@ class VariantIndexPresenter
       type: :variant,
       variant_types: variant.variant_types.map { |vt| VariantTypePresenter.new(vt) },
       civic_actionability_score: variant.civic_actionability_score,
+      flagged: variant.flagged,
       coordinates: {
         chromosome: variant.chromosome,
         start: variant.start,

--- a/db/migrate/20201022154530_add_flag_column.rb
+++ b/db/migrate/20201022154530_add_flag_column.rb
@@ -1,5 +1,6 @@
 class AddFlagColumn < ActiveRecord::Migration[5.2]
-  def change
+
+  def up
     [:evidence_items, :variants, :assertions, :variant_groups, :genes].each do |table|
       add_column table, :flagged, :boolean, null: false, index: true, default: false
     end
@@ -11,6 +12,13 @@ class AddFlagColumn < ActiveRecord::Migration[5.2]
           obj.save
         end
       end
+    end
+
+  end
+
+  def down
+    [:evidence_items, :variants, :assertions, :variant_groups, :genes].each do |table|
+      remove_column table, :flagged
     end
   end
 end

--- a/db/migrate/20201022154530_add_flag_column.rb
+++ b/db/migrate/20201022154530_add_flag_column.rb
@@ -1,0 +1,16 @@
+class AddFlagColumn < ActiveRecord::Migration[5.2]
+  def change
+    [:evidence_items, :variants, :assertions, :variant_groups, :genes].each do |table|
+      add_column table, :flagged, :boolean, null: false, index: true, default: false
+    end
+
+    [EvidenceItem, Variant, Assertion, VariantGroup, Gene].each do |klass|
+      klass.find_each do |obj|
+        if obj.flags.any? { |f| f.state == 'open' }
+          obj.flagged = true
+          obj.save
+        end
+      end
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -11,6 +11,8 @@ SET row_security = off;
 
 SET default_tablespace = '';
 
+SET default_table_access_method = heap;
+
 --
 -- Name: acmg_codes; Type: TABLE; Schema: public; Owner: -
 --
@@ -135,7 +137,8 @@ CREATE TABLE public.assertions (
     evidence_direction integer,
     summary text,
     variant_origin integer,
-    nccn_guideline_id bigint
+    nccn_guideline_id bigint,
+    flagged boolean DEFAULT false NOT NULL
 );
 
 
@@ -945,7 +948,8 @@ CREATE TABLE public.evidence_items (
     clinical_significance integer,
     deleted boolean DEFAULT false,
     deleted_at timestamp without time zone,
-    drug_interaction_type integer
+    drug_interaction_type integer,
+    flagged boolean DEFAULT false NOT NULL
 );
 
 
@@ -977,7 +981,8 @@ CREATE TABLE public.variants (
     ensembl_version integer,
     secondary_gene_id integer,
     civic_actionability_score double precision,
-    allele_registry_id text
+    allele_registry_id text,
+    flagged boolean DEFAULT false NOT NULL
 );
 
 
@@ -1127,7 +1132,8 @@ CREATE TABLE public.genes (
     updated_at timestamp without time zone,
     clinical_description text,
     deleted boolean DEFAULT false,
-    deleted_at timestamp without time zone
+    deleted_at timestamp without time zone,
+    flagged boolean DEFAULT false NOT NULL
 );
 
 
@@ -1794,7 +1800,8 @@ CREATE TABLE public.variant_groups (
     created_at timestamp without time zone,
     updated_at timestamp without time zone,
     deleted boolean DEFAULT false,
-    deleted_at timestamp without time zone
+    deleted_at timestamp without time zone,
+    flagged boolean DEFAULT false NOT NULL
 );
 
 
@@ -4001,6 +4008,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20200107192356'),
 ('20200131160152'),
 ('20200131160158'),
-('20200814141854');
+('20200814141854'),
+('20201022154530');
 
 


### PR DESCRIPTION
This introduces a new "flagged" status column for all flagged entities that will be kept up to date as flags are opened and resolved. Additionally it adds that status to the JSON responses for all flaggable entities.

closes griffithlab/civic-client#1513