### PR TITLE
Implement a job to update CIVIC's HPO records

### DIFF
--- a/app/jobs/update_human_phenotype_ontology.rb
+++ b/app/jobs/update_human_phenotype_ontology.rb
@@ -1,0 +1,5 @@
+class UpdateHumanPhenotypeOntology < ApplicationJob
+  def perform
+    Scrapers::HumanPhenotypeOntology.update
+  end
+end

--- a/config/scheduled_tasks.yml
+++ b/config/scheduled_tasks.yml
@@ -88,6 +88,12 @@ UpdateEntrezSymbols:
   queue: default
   class: UpdateEntrezSymbols
 
+UpdateHumanPhenotypeOntology:
+  cron: '0 0 * * 0'
+  description: Pull the latest version of the Human Phenotype Ontology and import it
+  queue: default
+  class: UpdateHumanPhenotypeOntology
+
 UpdateNciThesaurus:
   cron: '0 0 * * 0'
   description: Pull the latest version of the NCI Thesaurus and import it

--- a/lib/scrapers/human_phenotype_ontology.rb
+++ b/lib/scrapers/human_phenotype_ontology.rb
@@ -35,8 +35,20 @@ module Scrapers
           name = row.at_xpath('rdfs:label').text
           if !row.at_xpath('owl:deprecated').nil? && row.at_xpath('owl:deprecated').text == 'true'
             p = Phenotype.find_by(hpo_id: hpo_id)
-            if !p.nil? && p.evidence_items.count == 0 && p.assertions.count == 0
-              p.delete
+            if !p.nil?
+              if p.evidence_items.count == 0 && p.assertions.count == 0
+                p.delete
+              else
+                civicbot_user = User.find(385)
+                (p.evidence_items + p.assertions).each do |obj|
+                  if obj.flags.select{|f| f.state == 'open' && f.comments.select{|c| c.title == "Deprecated HPO term" && c.user_id = 385}.count > 0}.count == 0
+                    result = Flag.create_for_flaggable(civicbot_user, obj, nil)
+                    if result.succeeded?
+                      Comment.create({title: 'Deprecated HPO term', text: "This entity uses a deprecated HPO term \"#{name}\" (#{hpo_id})", user: civicbot_user, commentable: result.flag})
+                    end
+                  end
+                end
+              end
             end
           else
             p = Phenotype.where(hpo_id: hpo_id).first_or_create


### PR DESCRIPTION
We didn't have a job in place to update the HPO terms, which is why the Pediatric Onset term never got imported.

This new job grabs the HPO obo file and imports all term that are not deprecated. It updates existing term names and deletes terms that have become obsolete and have no evidence items or assertions that use the obsolete term. Any terms in active use would need to be manually fixed by making and accepting a suggested change to the affected evidence item/assertion. After them term has been removed from use the background job would take care of deleting the term next time it runs.

This job will run weekly.

Closes https://github.com/griffithlab/civic-client/issues/1417