### PR TITLE
Fix column name

### DIFF
--- a/app/datatables/variant_group_browse_table.rb
+++ b/app/datatables/variant_group_browse_table.rb
@@ -7,7 +7,7 @@ class VariantGroupBrowseTable < DatatableBase
   }.freeze
 
   ORDER_COLUMN_MAP = {
-    'name'                => 'variant_group_name',
+    'name'                => 'variant_groups.name',
     'variants'            => 'variants_names',
     'entrez_genes'        => 'entrez_names',
     'variant_count'       => 'variant_count',


### PR DESCRIPTION
When sorting the variant group data table by name we'd get an error as the
column name was incorrect. This corrects it.

https://griffithlab-apps.airbrake.io/projects/285901/groups/2860600362368029143/notices/2860600354194289502