### PR TITLE
Hotfix the DO update job

### DIFF
--- a/app/jobs/update_disease_ontology.rb
+++ b/app/jobs/update_disease_ontology.rb
@@ -34,6 +34,6 @@ class UpdateDiseaseOntology < ApplicationJob
   end
 
   def latest_doid_path
-    "https://raw.githubusercontent.com/DiseaseOntology/HumanDiseaseOntology/master/src/ontology/subsets/DO_cancer_slim.obo"
+    "https://raw.githubusercontent.com/DiseaseOntology/HumanDiseaseOntology/main/src/ontology/subsets/DO_cancer_slim.obo"
   end
 end

--- a/lib/scrapers/disease_ontology.rb
+++ b/lib/scrapers/disease_ontology.rb
@@ -26,7 +26,7 @@ module Scrapers
     end
 
     def self.url_from_doid(doid)
-      URI.parse("http://www.disease-ontology.org/api/metadata/DOID:#{doid}/")
+      URI.parse("https://www.disease-ontology.org/api/metadata/DOID:#{doid}/")
     end
   end
 end


### PR DESCRIPTION
Currently, the DO update job is failing because DO has updated some of their URLs. This is causing terms to not be imported/updated (e.g. https://github.com/griffithlab/civic-client/issues/1555). 

The commits in this PR are already part of https://github.com/griffithlab/civic-server/pull/654 but since that is waiting on a submission of an issue to DO to add additional terms to the cancer slim file, this PR will in the meantime fix the failing update job.

Closes https://github.com/griffithlab/civic-client/issues/1555