### PR TITLE
Admin eid fix

### DIFF
--- a/app/admin/dashboard.rb
+++ b/app/admin/dashboard.rb
@@ -13,7 +13,7 @@ ActiveAdmin.register_page 'Dashboard' do
         end
         panel "Evidence Items Requiring Action" do
           ul do
-            EvidenceItem.includes(:submitter).where(status: 'submitted').map do |ei|
+            EvidenceItem.includes(:submitter).where(status: 'submitted').limit(10).map do |ei|
               li link_to("#{ei.name} (by #{ei.submitter.try(:display_name)} #{time_ago_in_words(ei.created_at)} ago)", admin_evidence_item_path(ei))
             end
           end

--- a/app/admin/utilities.rb
+++ b/app/admin/utilities.rb
@@ -313,7 +313,7 @@ ActiveAdmin.register_page 'Utilities' do
               'Not all ids in the list are Illumina EIDs'
             else
               eids.each do |eid|
-                RemoveEvidenceItem.new(eid).perform
+                RemoveEvidenceItem.new.perform(eid)
               end
               'Done'
             end


### PR DESCRIPTION
Two small things:

* When doing foreground processing the arg is passed to perform rather than the constructor
* Keep "eids requiring action" from loading everything so the admin dashboard doesn't take forever to load