### PR TITLE
Only enqueue notifications after commit

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -7,7 +7,7 @@ class Event < ActiveRecord::Base
 
   serialize :state_params, JSON
 
-  after_create :queue_feed_updates
+  after_commit :queue_feed_updates, on: [:create]
   before_save :store_state_params
   before_create :capture_event_and_organization
 


### PR DESCRIPTION
It appears that, in certain circumstances, notification jobs are getting enqueued and then processed before the event that triggers them has fully committed to the db.  This is the cause of at least some of the errors seen here: https://griffithlab-apps.airbrake.io/projects/285901/groups/2811166032466336480


References:
https://stackoverflow.com/questions/43809727/rails-activejob-sqs-and-record-still-not-exists-when-executing-the-job
https://github.com/mperham/sidekiq/issues/322

As mentioned in the github issue, we can also introduce a slight delay but that seems hacky and I'd like to avoid it if we can.

