### PR TITLE
increase connection pool size.

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -18,4 +18,5 @@ test:
 
 production:
   <<: *default
+  pool: 20
   database: civic


### PR DESCRIPTION
When all background workers are busy and multiple workers were
concurrently servicing requests, we would rarely exhaust the
number of available database connections and get a timeout.

This will resolve that.

Reference: https://griffithlab-apps.airbrake.io/projects/285901/groups/2893304915349528334/notices/2893304959159953323

