### PR TITLE
Parse input as numeric when a numeric comparison is requested

### DIFF
--- a/app/models/advanced_searches/base.rb
+++ b/app/models/advanced_searches/base.rb
@@ -104,7 +104,24 @@ module AdvancedSearches
       else
         '%s'
       end
-      sprintf(fragment, param)
+
+      if is_numeric_operation?(operation_type)
+        sprintf(fragment, param.to_f)
+      else
+        sprintf(fragment, param)
+      end
+    end
+
+    def is_numeric_operation?(operation)
+      [
+        'is_above',
+        'is_below',
+        'is_less_than',
+        'is_greater_than',
+        'is_greater_than_or_equal_to',
+        'is_less_than_or_equal_to',
+        'is_in_the_range'
+      ].include?(operation)
     end
   end
 end


### PR DESCRIPTION
In the advanced search, if a user enters a non-numeric value when requesting a numeric comparison, it will generate a (still safe but) invalid SQL statement which will cause an exception. (https://griffithlab-apps.airbrake.io/projects/285901/groups/2894318614931625648/notices/2894318613519076496)

Ideally we'd do more validation client side and server side and kick back a more user friendly error in this case, but as a stopgap this will at least ensure the prepared SQL is valid and no error will occur. 