### PR TITLE
Fix logic of when to set the allele registry id

### DIFF
--- a/app/jobs/set_allele_registry_id_single_variant.rb
+++ b/app/jobs/set_allele_registry_id_single_variant.rb
@@ -4,15 +4,13 @@ class SetAlleleRegistryIdSingleVariant < AlleleRegistryIds
 
   def perform(variant)
     allele_registry_id = get_allele_registry_id(variant)
-    if allele_registry_id != variant.allele_registry_id
-      if allele_registry_id == '_:CA'
-        variant.allele_registry_id = 'unregistered'
-        variant.save
-      elsif allele_registry_id.present?
-        variant.allele_registry_id = allele_registry_id
-        variant.save
-        add_allele_registry_link(allele_registry_id)
-      end
+    if allele_registry_id == '_:CA' && variant.allele_registry_id != 'unregistered'
+      variant.allele_registry_id = 'unregistered'
+      variant.save
+    elsif allele_registry_id.present? && allele_registry_id != variant.allele_registry_id
+      variant.allele_registry_id = allele_registry_id
+      variant.save
+      add_allele_registry_link(allele_registry_id)
     end
   end
 end


### PR DESCRIPTION
Previously, the check would not catch the case where the allele registry id came back as `_:CA`. We would then set the allele registry id again to 'unregistered' which would trigger another round of this job getting called, creating an infinite loop.