### PR TITLE
Add additional disease terms that need special handling

### DIFF
--- a/lib/importer/disease_ontology_mirror.rb
+++ b/lib/importer/disease_ontology_mirror.rb
@@ -100,7 +100,7 @@ module Importer
           resp = Net::HTTP.get_response(uri)
           if resp.code == '200'
             #DOID exists but isn't in the cancer slim file
-            if ['3852', '8432', '0060474', '3883', '14175', '3012', '0111503'].include? d.doid
+            if ['3852', '8432', '0060474', '3883', '14175', '3012', '0111503', '13481', '3205', '0111359'].include? d.doid
               #Non-cancer diseases don't belong in the cancer slim file and
               #need to be updated using the data returned by the API
               metadata = JSON.parse(resp.body)

--- a/lib/importer/disease_ontology_mirror.rb
+++ b/lib/importer/disease_ontology_mirror.rb
@@ -129,6 +129,8 @@ module Importer
         if d.evidence_items.count == 0 and d.assertions.count == 0
           d.disease_aliases.clear
           d.delete
+        elsif ['Solid Tumor', 'Ventricular Dysfunction', 'Acute Mountain Sickness', 'Glioma', 'Low Bone Mineral Density'].include? d.name
+          next
         else
           #Disease needs to have its DOID backfilled or needs to be added to
           #the DO to being with


### PR DESCRIPTION
This PR adds a few DOIDs that are not in the cancer slim file and do not belong there but we still want to support them in CIViC.

It also handles a new class of disease terms that the DO does not wish to include in their ontology and so will never have a DOID.