### PR TITLE
Fill in full_journal_title for ASCO abstracts

### DIFF
--- a/lib/scrapers/asco.rb
+++ b/lib/scrapers/asco.rb
@@ -43,6 +43,7 @@ module Scrapers
       source.journal = record_resp.journal
       source.name = record_resp.article_title
       source.abstract = record_resp.abstract
+      source.full_journal_title = 'Journal of Clinical Oncology'
       nct_id = record_resp.nct_id
       if not nct_id.empty?
         source.clinical_trials << ::ClinicalTrial.where(nct_id: nct_id).first_or_create


### PR DESCRIPTION
This value was not previously set, and it is now hardcoded for ASCO sources. We have backfilled this for existing sources, and this should fix the issue going forward.

We will also want to regenerate clinical trial associations.

closes griffithlab/civic-client#1612