### PR TITLE
Gracefully handle ORCID login when user hasn't specified a name

### DIFF
--- a/app/api_helpers/orcid_api.rb
+++ b/app/api_helpers/orcid_api.rb
@@ -6,11 +6,20 @@ class OrcidApi
   end
 
   def name
-    details = user_data['person']['name']
-    [
-      details['given-names']['value'],
-      details['family-name']['value'],
+    name = [
+      user_data.dig('person', 'name', 'given-names', 'value'),
+      user_data.dig('person', 'name', 'family-name', 'value')
     ].join(' ')
+
+    if name.present?
+      name
+    else
+      orcid
+    end
+  end
+
+  def orcid
+     user_data['orcid-identifier']['path']
   end
 
   private

--- a/app/models/user_adaptors/orcid.rb
+++ b/app/models/user_adaptors/orcid.rb
@@ -10,6 +10,9 @@ module UserAdaptors
     def self.fill_user_record_from_orcid(user)
       api_client = OrcidApi.new(user.orcid)
       user.name = api_client.name
+      if user.orcid.blank?
+        user.orcid = api_client.orcid
+      end
     end
   end
 end


### PR DESCRIPTION
Something seems to have changed in their API responses. This field was previously always present but in some cases it no longer is. 

In the case when we have no family or given name, we'll fall back on the orcid itself as a new user's name.

